### PR TITLE
Fix private URL handling and batch upload performance

### DIFF
--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -7,6 +7,9 @@ performs the add, then closes automatically.
 
 Headed mode is required because Speechify's "Paste Link" feature uses the real
 system clipboard API, which only works correctly in a visible browser window.
+
+BrowserSession keeps Playwright + Chromium alive across multiple operations
+so that batch uploads don't pay the ~17s cold-start per file.
 """
 
 import asyncio
@@ -18,6 +21,144 @@ from pathlib import Path
 from . import config
 
 SCREENSHOT_DIR = Path.home() / ".config" / "speechify-add" / "debug-screenshots"
+
+
+# ---------------------------------------------------------------------------
+# BrowserSession — reusable session for batch operations
+# ---------------------------------------------------------------------------
+
+class BrowserSession:
+    """Async context manager that keeps a single Chromium instance alive.
+
+    Usage:
+        async with BrowserSession(debug=False) as session:
+            await session.add_url("https://example.com/article1")
+            await session.add_text("some text", title="My Doc")
+            await session.add_url("https://example.com/article2")
+    """
+
+    def __init__(self, debug: bool = False):
+        self.debug = debug
+        self._playwright = None
+        self._ctx = None
+        self._page = None
+        self._xvfb_proc = None
+        self._console_errors: list[str] = []
+
+    async def __aenter__(self):
+        from playwright.async_api import async_playwright
+
+        profile_dir = config.BROWSER_PROFILE_DIR
+        if not profile_dir.exists():
+            raise RuntimeError("No browser profile found. Run: speechify-add auth setup")
+
+        _display, self._xvfb_proc = _ensure_display()
+
+        self._pw_cm = async_playwright()
+        self._playwright = await self._pw_cm.__aenter__()
+        self._ctx = await self._playwright.chromium.launch_persistent_context(
+            str(profile_dir),
+            headless=False,
+            args=["--disable-blink-features=AutomationControlled"],
+            permissions=["clipboard-read", "clipboard-write"],
+        )
+        self._page = await self._ctx.new_page()
+        self._page.on("pageerror", lambda err: self._console_errors.append(str(err)))
+
+        await self._page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
+        await self._page.locator('[data-testid="sidebar-import-button"]').wait_for(
+            state="visible", timeout=15_000
+        )
+        await self._page.wait_for_timeout(1_000)
+        _assert_logged_in(self._page)
+
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._ctx:
+            await self._ctx.close()
+        if self._pw_cm:
+            await self._pw_cm.__aexit__(exc_type, exc_val, exc_tb)
+        if self._xvfb_proc is not None:
+            self._xvfb_proc.terminate()
+            self._xvfb_proc.wait()
+        return False
+
+    async def _navigate_to_library(self):
+        """Navigate back to the Speechify library between operations."""
+        await self._page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
+        await self._page.locator('[data-testid="sidebar-import-button"]').wait_for(
+            state="visible", timeout=15_000
+        )
+        await self._page.wait_for_timeout(1_000)
+
+    async def add_url(self, url: str) -> None:
+        """Add a URL via the Paste Link flow, reusing the open browser."""
+        self._console_errors.clear()
+
+        if self.debug:
+            _save_screenshot(self._page, "batch-url-01-before")
+
+        await _perform_add(self._page, url, debug=self.debug)
+
+        crashed = await self._page.locator("text=Application error").count()
+        if crashed > 0:
+            raise RuntimeError(
+                f"Speechify app crashed after Paste Link.\n"
+                f"Page errors: {self._console_errors[:3]}"
+            )
+
+        # Navigate back to library for the next operation
+        await self._navigate_to_library()
+
+    async def add_text(self, text: str, title: str = "") -> str:
+        """Add raw text via the Paste Text flow, reusing the open browser."""
+        page = self._page
+
+        if self.debug:
+            _save_screenshot(page, "batch-text-01-before")
+
+        # Open "New" menu
+        await page.locator('[data-testid="sidebar-import-button"]').click()
+        await page.wait_for_timeout(600)
+
+        # Click "Paste Text"
+        await page.locator('[data-testid="library-menu-item-paste-text"]').click()
+        await page.wait_for_timeout(1_000)
+
+        if self.debug:
+            _save_screenshot(page, "batch-text-02-modal")
+
+        # Fill title and text
+        if title:
+            await page.locator('input[placeholder="Optional"]').fill(title)
+        await page.locator('textarea[placeholder="Type or paste text here"]').fill(text)
+        await page.wait_for_timeout(500)
+
+        # Click "Save File"
+        await page.locator('[data-testid="add-text-save-button"]').click()
+
+        # Wait for redirect to /item/<uuid>
+        doc_url = ""
+        for _ in range(30):
+            await page.wait_for_timeout(1_000)
+            if "/item/" in page.url:
+                doc_url = page.url
+                break
+
+        if not doc_url:
+            raise RuntimeError(
+                "Timed out waiting for Speechify to process the text. "
+                f"Final URL: {page.url}"
+            )
+
+        if self.debug:
+            _save_screenshot(page, "batch-text-03-done")
+
+        # Navigate back to library for the next operation
+        await self._navigate_to_library()
+
+        return doc_url
 
 
 def _ensure_display():

--- a/speechify_add/cli.py
+++ b/speechify_add/cli.py
@@ -10,9 +10,11 @@ Usage:
 """
 
 import asyncio
+import re
 import sys
 
 import click
+import httpx
 
 
 def _run(coro):
@@ -55,6 +57,11 @@ def add(ctx, url, file_path, from_stdin, mode):
         click.echo(ctx.get_help())
         return
 
+    # Use batch mode (single browser session) when we have multiple URLs
+    if len(urls) > 1 and mode == "browser":
+        _run(_add_batch(urls))
+        return
+
     success = fail = 0
     for u in urls:
         try:
@@ -91,13 +98,117 @@ def _collect_urls(url, file_path, from_stdin) -> list[str]:
     return []
 
 
+_GOOGLE_DOCS_RE = re.compile(
+    r"https://docs\.google\.com/document/d/([a-zA-Z0-9_-]+)"
+)
+
+
+def _is_google_doc(url: str) -> bool:
+    return _GOOGLE_DOCS_RE.match(url) is not None
+
+
+def _google_doc_export_url(url: str) -> str:
+    """Convert a Google Docs URL to its plain-text export URL."""
+    m = _GOOGLE_DOCS_RE.match(url)
+    if not m:
+        raise ValueError(f"Not a Google Docs URL: {url}")
+    doc_id = m.group(1)
+    return f"https://docs.google.com/document/d/{doc_id}/export?format=txt"
+
+
+def _fetch_google_doc_text(url: str) -> str:
+    """Download a Google Doc as plain text via the public export endpoint."""
+    export_url = _google_doc_export_url(url)
+    resp = httpx.get(export_url, follow_redirects=True, timeout=30)
+    if resp.status_code in (401, 403):
+        raise RuntimeError(
+            f"Google Doc is private (HTTP {resp.status_code}). "
+            "Make the document publicly accessible, or copy the text manually "
+            "and use: speechify-add text --stdin -t \"Title\""
+        )
+    if resp.status_code == 404:
+        raise RuntimeError(
+            "Google Doc not found (404). Check that the URL is correct."
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"Google Doc export failed (HTTP {resp.status_code}). "
+            "Try sharing the document publicly or exporting manually."
+        )
+    return resp.text
+
+
+def _precheck_url(url: str) -> None:
+    """HTTP HEAD pre-check: raise if the URL requires authentication."""
+    try:
+        resp = httpx.head(url, follow_redirects=True, timeout=15)
+    except httpx.HTTPError:
+        # Network errors are not auth problems — let Speechify try it
+        return
+    if resp.status_code in (401, 403):
+        raise RuntimeError(
+            f"URL returned HTTP {resp.status_code} (unauthorized/forbidden). "
+            "Speechify won't be able to access this content. "
+            "Download the text and use: speechify-add text --stdin -t \"Title\""
+        )
+
+
 async def _add_one(url: str, mode: str) -> None:
     from . import api, browser
+
+    # Google Docs: export as text and upload via the text path
+    if _is_google_doc(url):
+        text = _fetch_google_doc_text(url)
+        # Derive a title from the first non-empty line
+        title = ""
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped:
+                title = stripped[:120]
+                break
+        await browser.add_text(text, title=title)
+        return
+
+    # For all other URLs, pre-check accessibility
+    _precheck_url(url)
 
     if mode == "api":
         await api.add_url(url)
     else:
         await browser.add_url(url)
+
+
+async def _add_batch(urls: list[str]) -> None:
+    """Add multiple URLs using a single browser session (much faster)."""
+    from .browser import BrowserSession
+
+    success = fail = 0
+    async with BrowserSession() as session:
+        for url in urls:
+            try:
+                if _is_google_doc(url):
+                    text = _fetch_google_doc_text(url)
+                    title = ""
+                    for line in text.splitlines():
+                        stripped = line.strip()
+                        if stripped:
+                            title = stripped[:120]
+                            break
+                    await session.add_text(text, title=title)
+                else:
+                    _precheck_url(url)
+                    await session.add_url(url)
+                click.echo(f"✓  {url}")
+                success += 1
+            except Exception as e:
+                click.echo(f"✗  {url}\n   {e}", err=True)
+                fail += 1
+
+    if len(urls) > 1:
+        click.echo(f"\n{success} added, {fail} failed")
+
+    if fail:
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Issue #1** — Private URLs (e.g. Google Docs) now detected and handled instead of silently failing. Google Docs URLs are exported as plain text and uploaded via the text path. Other URLs get an HTTP HEAD pre-check that errors on 401/403.
- **Issue #2** — New `BrowserSession` class keeps Playwright + Chromium alive across multiple uploads. Batch mode (`--file`/`--stdin` with multiple URLs) pays the browser startup cost once instead of per-URL.

Closes #1, closes #2

## Test plan
- [x] Google Docs URL detection (regex matching + export URL generation)
- [x] Private/missing Google Doc returns clear error message
- [x] URL precheck passes public URLs, errors on 401/403
- [x] Network errors in precheck don't block the add
- [x] Single URL add still works (backward compat)
- [x] Batch add with 2 URLs via `--stdin` uses shared browser session
- [x] BrowserSession cleanup (`__aexit__`) works without errors
- [x] CLI help output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)