### PR TITLE
Fall back to chrome-hub for Firebase token when refresh fails

### DIFF
--- a/speechify_add/auth.py
+++ b/speechify_add/auth.py
@@ -50,9 +50,8 @@ async def _refresh_id_token(data: dict) -> str:
     api_key = data.get("firebase_api_key")
 
     if not refresh_token or not api_key:
-        raise RuntimeError(
-            "Missing refresh token or Firebase API key. Run: speechify-add auth setup"
-        )
+        # Try chrome-hub fallback before giving up
+        return await _refresh_from_chrome_hub(data)
 
     async with httpx.AsyncClient() as client:
         resp = await client.post(
@@ -61,11 +60,9 @@ async def _refresh_id_token(data: dict) -> str:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=15,
         )
-        if resp.status_code == 400:
-            raise RuntimeError(
-                "Token refresh failed (HTTP 400) — your session may have expired "
-                "or been revoked. Run: speechify-add auth setup"
-            )
+        if resp.status_code in (400, 403):
+            # Firebase refresh failed — try extracting fresh tokens from chrome-hub
+            return await _refresh_from_chrome_hub(data)
         resp.raise_for_status()
 
     result = resp.json()
@@ -75,6 +72,53 @@ async def _refresh_id_token(data: dict) -> str:
     data["id_token"] = id_token
     data["refresh_token"] = result.get("refresh_token", refresh_token)
     data["id_token_expires_at"] = time.time() + expires_in
+    config.save(data)
+
+    return id_token
+
+
+async def _refresh_from_chrome_hub(data: dict) -> str:
+    """Extract fresh Firebase tokens from chrome-hub's logged-in Chrome session."""
+    try:
+        from chrome_hub import async_new_page
+    except ImportError:
+        raise RuntimeError(
+            "Token refresh failed and chrome-hub is not installed. "
+            "Run: speechify-add auth setup"
+        )
+
+    async with async_new_page() as page:
+        await page.goto("https://app.speechify.com", wait_until="load", timeout=30_000)
+        await page.wait_for_timeout(3_000)
+
+        if "auth" in page.url:
+            raise RuntimeError(
+                "Chrome-hub session is not logged into Speechify. "
+                "Run: speechify-add auth setup"
+            )
+
+        records = await _read_firebase_indexeddb(page)
+
+    captured: dict = {}
+    _extract_firebase_tokens(records, captured)
+
+    id_token = captured.get("id_token")
+    if not id_token:
+        raise RuntimeError(
+            "Could not extract Firebase token from chrome-hub session. "
+            "Run: speechify-add auth setup"
+        )
+
+    # Update stored auth data with fresh tokens
+    data["id_token"] = id_token
+    if captured.get("refresh_token"):
+        data["refresh_token"] = captured["refresh_token"]
+    if captured.get("firebase_api_key"):
+        data["firebase_api_key"] = captured["firebase_api_key"]
+    if captured.get("id_token_expires_at"):
+        data["id_token_expires_at"] = captured["id_token_expires_at"]
+    else:
+        data["id_token_expires_at"] = time.time() + 3600
     config.save(data)
 
     return id_token

--- a/speechify_add/cli.py
+++ b/speechify_add/cli.py
@@ -284,26 +284,31 @@ def _parse_item_id(item: str) -> str:
 
 @cli.command()
 @click.argument("item", required=True)
-def delete(item):
+@click.option("--mode", type=click.Choice(["browser", "api"]), default="browser",
+              show_default=True, help="browser: uses chrome-hub (default). api: Firebase API (requires valid token).")
+@click.option("--debug", is_flag=True, help="Save debug screenshots")
+def delete(item, mode, debug):
     """Delete an item from your Speechify library.
 
     ITEM can be a full URL (https://app.speechify.com/item/UUID)
     or just the UUID.
-
-    Uses the archiveLibraryItem API — no browser needed.
     """
     item_id = _parse_item_id(item)
     try:
-        _run(_do_delete(item_id))
+        _run(_do_delete(item_id, mode=mode, debug=debug))
         click.echo(f"Deleted {item_id}")
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
 
-async def _do_delete(item_id: str) -> None:
-    from . import api
-    await api.delete_item(item_id)
+async def _do_delete(item_id: str, mode: str = "browser", debug: bool = False) -> None:
+    if mode == "api":
+        from . import api
+        await api.delete_item(item_id)
+    else:
+        from . import browser
+        await browser.delete_item(item_id, debug=debug)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When stored Firebase refresh token is expired/revoked (400/403), `auth.py` now extracts a fresh token from chrome-hub's live Chrome session via IndexedDB
- Updates stored auth data with fresh tokens so subsequent calls don't need chrome-hub
- Adds `--mode browser|api` flag to delete command
- No manual `auth setup` needed as long as Chrome is logged in via chrome-hub

## Test plan
- [x] Verified delete works with expired Firebase token (falls back to chrome-hub)
- [x] Verified text upload still works via chrome-hub browser automation
- [x] Token extraction from IndexedDB returns valid accessToken + refreshToken
- [ ] Verify cleanup timer still works with new delete path

🤖 Generated with [Claude Code](https://claude.com/claude-code)