### PR TITLE
fix: get_page_title: support multiline title tags

### DIFF
--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -127,7 +127,7 @@ async def get_page_title(url: str) -> str | None:
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=10) as client:
             resp = await client.get(url, headers={"User-Agent": "Mozilla/5.0"})
-            match = re.search(r"<title[^>]*>([^<]+)</title>", resp.text, re.IGNORECASE)
+            match = re.search(r"<title[^>]*>(.*?)</title>", resp.text, re.IGNORECASE | re.DOTALL)
             if match:
                 return html.unescape(match.group(1).strip())
     except Exception:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -88,6 +88,13 @@ class TestGetPageTitle:
         assert result == "Upper Title"
 
     @pytest.mark.asyncio
+    async def test_multiline_title(self):
+        cm = _mock_httpx_client("<title>\n  Multiline Title\n</title>")
+        with patch("speechify_add.verify.httpx.AsyncClient", return_value=cm):
+            result = await get_page_title("https://example.com")
+        assert result == "Multiline Title"
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_no_title_tag(self):
         cm = _mock_httpx_client("<html><body>No title here</body></html>")
         with patch("speechify_add.verify.httpx.AsyncClient", return_value=cm):


### PR DESCRIPTION
## Summary
- Fixes `get_page_title` regex to match `<title>` elements that span multiple lines (some sites pretty-print HTML this way)
- Changes `([^<]+)` to `(.*?)` with `re.DOTALL` flag so `.` matches newlines
- Keeps existing `html.unescape` + `.strip()` post-processing unchanged
- Adds a unit test for the multiline case

## Test plan
- [x] Existing unit tests pass (`python3 -m pytest tests/test_verify.py` — 25 passed)
- [x] New `test_multiline_title` test covers the multiline case

Closes #27

Generated with [Claude Code](https://claude.com/claude-code)