### PR TITLE
fix: Harden CONFIG_DIR permissions to 0700 (closes #26)

### DIFF
--- a/speechify_add/config.py
+++ b/speechify_add/config.py
@@ -18,7 +18,8 @@ def load() -> dict:
 
 
 def save(data: dict):
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(CONFIG_DIR, 0o700)
     # Atomic write: create temp file with restricted permissions, then rename.
     # Avoids a TOCTOU race where auth.json is briefly world-readable.
     fd, temp_path = tempfile.mkstemp(dir=CONFIG_DIR, suffix=".tmp")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,6 +113,23 @@ class TestSave:
         file_mode = stat.S_IMODE(auth_file.stat().st_mode)
         assert file_mode == 0o600
 
+    def test_config_dir_permissions_are_0o700(self, tmp_path):
+        config_dir, auth_file = _patch_paths(tmp_path)
+        with patch.object(config, "CONFIG_DIR", config_dir), \
+             patch.object(config, "AUTH_FILE", auth_file):
+            config.save({"x": 1})
+        dir_mode = stat.S_IMODE(config_dir.stat().st_mode)
+        assert dir_mode == 0o700
+
+    def test_config_dir_chmod_applied_to_existing_dir(self, tmp_path):
+        config_dir, auth_file = _patch_paths(tmp_path)
+        config_dir.mkdir(parents=True, mode=0o755)
+        with patch.object(config, "CONFIG_DIR", config_dir), \
+             patch.object(config, "AUTH_FILE", auth_file):
+            config.save({"x": 1})
+        dir_mode = stat.S_IMODE(config_dir.stat().st_mode)
+        assert dir_mode == 0o700
+
     def test_no_temp_file_left_after_success(self, tmp_path):
         config_dir, auth_file = _patch_paths(tmp_path)
         with patch.object(config, "CONFIG_DIR", config_dir), \


### PR DESCRIPTION
Automated implementation of #26: Harden CONFIG_DIR permissions to 0700

Original issue: https://github.com/Josephkready/speechify-add/issues/26

Please review before merging.