### PR TITLE
fix: Parse comma-separated downloadTokens from Firebase Storage

### DIFF
--- a/speechify_add/api.py
+++ b/speechify_add/api.py
@@ -122,7 +122,7 @@ async def _upload_empty(client: httpx.AsyncClient, id_token: str,
         raise RuntimeError(
             f"Firebase Storage returned non-JSON response: {resp.text[:200]}"
         )
-    token = data.get("downloadTokens")
+    token = data.get("downloadTokens", "").split(",")[0]
     if not token:
         raise RuntimeError(
             f"Firebase Storage did not return a download token. Response: "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,6 +73,16 @@ class TestUploadEmpty:
             await api._upload_empty(client, "tok", "some/path")
 
     @pytest.mark.asyncio
+    async def test_comma_separated_download_tokens_uses_first(self):
+        """Firebase may return multiple comma-separated tokens; only the first is used."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.post.return_value = _mock_response(
+            200, json_body={"downloadTokens": "first-token,second-token,third-token"}
+        )
+        token = await api._upload_empty(client, "tok", "some/path")
+        assert token == "first-token"
+
+    @pytest.mark.asyncio
     async def test_upload_url_encodes_storage_path(self):
         """Verify the storage path is URL-encoded in the upload request."""
         client = AsyncMock(spec=httpx.AsyncClient)


### PR DESCRIPTION
## Summary
- Firebase Storage's `downloadTokens` field can return a comma-separated list of token UUIDs
- Fixed `_upload_empty` in `speechify_add/api.py` to split on `,` and use the first token
- Added a test to verify the fix handles multiple comma-separated tokens correctly

## Test plan
- [x] New test `test_comma_separated_download_tokens_uses_first` covers the multi-token case
- [x] All 20 existing tests pass (`python3 -m pytest tests/test_api.py -q`)

Closes #25

Generated with [Claude Code](https://claude.com/claude-code)