### PR TITLE
fix: add Referer header to Firebase token refresh

### DIFF
--- a/speechify_add/auth.py
+++ b/speechify_add/auth.py
@@ -57,7 +57,7 @@ async def _refresh_id_token(data: dict) -> str:
         resp = await client.post(
             f"https://securetoken.googleapis.com/v1/token?key={api_key}",
             data={"grant_type": "refresh_token", "refresh_token": refresh_token},
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Referer": "https://app.speechify.com/"},
             timeout=15,
         )
         if resp.status_code in (400, 403):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -224,6 +224,25 @@ class TestRefreshIdToken:
         mock_config.save.assert_called_once_with(data)
 
     @pytest.mark.asyncio
+    async def test_sends_referer_header(self):
+        """Firebase API key requires Referer: https://app.speechify.com/ to avoid 403."""
+        data = {"firebase_api_key": "k", "refresh_token": "old-rt"}
+        firebase_resp = {"id_token": "new-id", "refresh_token": "new-rt", "expires_in": "3600"}
+        mock_resp = self._make_httpx_response(200, firebase_resp)
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("speechify_add.auth.config"), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            await auth._refresh_id_token(data)
+
+        _, kwargs = mock_client.post.call_args
+        headers = kwargs.get("headers", {})
+        assert headers.get("Referer") == "https://app.speechify.com/"
+
+    @pytest.mark.asyncio
     async def test_preserves_old_refresh_token_if_not_in_response(self):
         data = {"firebase_api_key": "k", "refresh_token": "old-rt"}
         firebase_resp = {"id_token": "new-id", "expires_in": "3600"}


### PR DESCRIPTION
## Summary
- Firebase's `securetoken.googleapis.com` returns 403 (`API_KEY_HTTP_REFERRER_BLOCKED`) when the request has no `Referer` header
- The API key is restricted to requests originating from `app.speechify.com`
- Adding `Referer: https://app.speechify.com/` to the token refresh POST fixes the 403 and allows headless token refresh to succeed without falling back to the chrome-hub browser flow

## Test plan
- [ ] `speechify-add auth refresh` succeeds after token expiry without opening a browser

Generated with [Claude Code](https://claude.com/claude-code)