### PR TITLE
feat: file-upload command + public Python API (closes #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ speechify_add/
 
 ---
 
+## Tests
+
+Pure-logic tests run with no external services and no auth:
+
+```bash
+pytest -m "not live"
+```
+
+Live tests round-trip through the real Speechify backend (upload → search → delete). They require a working browser profile from `auth setup` and skip cleanup-protect — failures may leave a stray item in your library:
+
+```bash
+pytest -m live
+```
+
+---
+
 ## Disclaimer
 
 This tool uses Speechify's undocumented internal API. It is not affiliated with or endorsed by Speechify Inc. Use it for personal use with your own account. The API can change at any time without notice.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ speechify-add auth refresh
 
 ---
 
----
-
 ## Python API
 
 `speechify-add` is also importable from Python — useful for downstream pipelines (`medium-fetch`, `book-to-speechify`, `hn-digest`, …) that want to push content to Speechify without shelling out:
@@ -174,7 +172,7 @@ Pure-logic tests run with no external services and no auth:
 pytest -m "not live"
 ```
 
-Live tests round-trip through the real Speechify backend (upload → search → delete). They require a working browser profile from `auth setup` and skip cleanup-protect — failures may leave a stray item in your library:
+Live tests round-trip through the real Speechify backend (upload → search → delete). They require a working browser profile from `auth setup`. Tests clean up after themselves in a `finally` block, but if a test crashes hard you may need to delete the stray item manually:
 
 ```bash
 pytest -m live

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ cat summary.txt | speechify-add text --stdin -t "Daily Summary"
 
 Returns the Speechify document URL on success. Handles large files (tested up to 700K chars).
 
+### Add a file (PDF / EPUB / HTML / TXT)
+
+Upload an actual file via Speechify's "Import file" flow — preserves images and formatting that the `text` command flattens away:
+
+```bash
+speechify-add file article.pdf -t "On Re-reading LOTR"
+speechify-add file book.epub
+```
+
+Supported extensions: `.pdf`, `.epub`, `.html`, `.htm`, `.txt`. The `--title` flag is best-effort: Speechify usually extracts the title from the file's own metadata (PDFs especially), and the import dialog may not expose a title field. Returns the Speechify document URL on success.
+
 ### Delete an item
 
 Remove an item from your Speechify library:
@@ -100,12 +111,34 @@ speechify-add auth refresh
 
 ---
 
+---
+
+## Python API
+
+`speechify-add` is also importable from Python — useful for downstream pipelines (`medium-fetch`, `book-to-speechify`, `hn-digest`, …) that want to push content to Speechify without shelling out:
+
+```python
+from pathlib import Path
+from speechify_add import upload_text, upload_file, upload_url
+
+# Each call returns the Speechify item URL on success.
+url = upload_text("hello world", title="Test")
+url = upload_file(Path("article.pdf"), title="On Re-reading LOTR")
+url = upload_url("https://example.com/article")
+```
+
+All three are sync wrappers around the underlying async browser flows — they manage the event loop internally, so callers don't need to. Auth comes from the persistent browser profile created by `speechify-add auth setup`.
+
+`upload_url` returns an empty string if Speechify accepted the URL but didn't redirect to the item page within ~15 seconds (the URL was still queued — we just couldn't observe its id).
+
+---
+
 ## How It Works
 
 | Approach | Used by | How |
 |---|---|---|
 | **Consumer API** | `delete` | Direct HTTP calls to Speechify's Firebase Cloud Functions |
-| **Browser automation** | `add`, `text` | Drives headed Chromium via Playwright with a persistent login profile |
+| **Browser automation** | `add`, `text`, `file` | Drives headed Chromium via Playwright with a persistent login profile |
 
 The browser runs in headed mode (Speechify's clipboard API requires a visible window). On headless servers, Xvfb is used automatically as a virtual display.
 
@@ -115,10 +148,11 @@ The browser runs in headed mode (Speechify's clipboard API requires a visible wi
 
 ```
 speechify_add/
-  cli.py       # Click CLI (add, text, delete, verify, auth, debug)
+  __init__.py  # Public Python API (upload_text, upload_file, upload_url)
+  cli.py       # Click CLI (add, text, file, delete, verify, auth, debug)
   auth.py      # Firebase token capture, refresh, and storage
   api.py       # Direct API calls (add URL, delete item)
-  browser.py   # Playwright automation (add URL, add text)
+  browser.py   # Playwright automation (add URL, add text, add file)
   verify.py    # Library search via headless browser
   config.py    # Paths and configuration
 ```

--- a/speechify_add/__init__.py
+++ b/speechify_add/__init__.py
@@ -1,0 +1,56 @@
+"""Public Python API for speechify-add.
+
+These are the supported entrypoints for downstream code (medium-fetch,
+book-to-speechify, hn-digest, etc.). They are sync wrappers around the async
+browser flows so callers don't need to manage an event loop.
+
+Each function returns the Speechify item URL when observable.
+
+Examples:
+    from pathlib import Path
+    from speechify_add import upload_text, upload_file, upload_url
+
+    url = upload_text("hello world", title="Test")
+    url = upload_file(Path("article.pdf"), title="On Re-reading LOTR")
+    url = upload_url("https://example.com/article")
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Union
+
+from . import browser as _browser
+
+__all__ = ["upload_text", "upload_file", "upload_url"]
+
+
+def upload_text(text: str, title: str = "") -> str:
+    """Upload raw text or markdown to your Speechify library.
+
+    Returns the Speechify item URL on success.
+    """
+    return asyncio.run(_browser.add_text(text, title=title))
+
+
+def upload_file(path: Union[str, Path], title: str = "") -> str:
+    """Upload a file (.pdf/.epub/.html/.htm/.txt) to your Speechify library.
+
+    The browser's persistent profile is used for auth. ``title`` is best-effort:
+    if the import dialog exposes a title field it will be filled, otherwise
+    Speechify extracts the title from the file's own metadata.
+
+    Returns the Speechify item URL on success.
+    """
+    validated = _browser._validate_file_path(Path(path))
+    return asyncio.run(_browser.add_file(validated, title=title))
+
+
+def upload_url(url: str) -> str:
+    """Add a URL to your Speechify library via the Paste Link flow.
+
+    Returns the Speechify item URL if Speechify redirects within ~15 seconds;
+    returns an empty string if the URL was queued but the redirect wasn't
+    observable.
+    """
+    return asyncio.run(_browser.add_url(url))

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -17,6 +17,22 @@ from chrome_hub import async_new_page
 
 SCREENSHOT_DIR = Path.home() / ".config" / "speechify-add" / "debug-screenshots"
 
+SUPPORTED_FILE_EXTS = frozenset({".pdf", ".epub", ".html", ".htm", ".txt"})
+
+
+def _validate_file_path(path: Path) -> Path:
+    """Raise if `path` isn't a readable file with a Speechify-supported extension."""
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    if not path.is_file():
+        raise ValueError(f"Not a file: {path}")
+    if path.suffix.lower() not in SUPPORTED_FILE_EXTS:
+        supported = ", ".join(sorted(SUPPORTED_FILE_EXTS))
+        raise ValueError(
+            f"Unsupported file type: {path.suffix}. Supported: {supported}"
+        )
+    return path
+
 
 # ---------------------------------------------------------------------------
 # Helpers for page initialization
@@ -320,7 +336,14 @@ async def add_text(text: str, title: str = "", debug: bool = False) -> str:
         return doc_url
 
 
-async def add_url(url: str, debug: bool = False) -> None:
+async def add_url(url: str, debug: bool = False) -> str:
+    """Add a URL to Speechify via the Paste Link flow.
+
+    Returns the Speechify item URL if observable (page redirected to
+    /item/<uuid> within the timeout). Returns an empty string if Speechify
+    accepted the URL but didn't redirect — the URL was still queued, we just
+    couldn't observe its id.
+    """
     async with async_new_page() as page:
         console_errors = []
         page.on("pageerror", lambda err: console_errors.append(str(err)))
@@ -332,13 +355,99 @@ async def add_url(url: str, debug: bool = False) -> None:
 
         await _perform_add(page, url, debug=debug)
 
-        # Confirm the app didn't crash (Next.js error overlay)
         crashed = await page.locator("text=Application error").count()
         if crashed > 0:
             raise RuntimeError(
                 f"Speechify app crashed after Paste Link.\n"
                 f"Page errors: {console_errors[:3]}"
             )
+
+        try:
+            return await _wait_for_item_redirect(page, timeout_seconds=15)
+        except RuntimeError:
+            return ""
+
+
+async def add_file(path: Path, title: str = "", debug: bool = False) -> str:
+    """Upload a file (.pdf/.epub/.html/.txt) via Speechify's Import-file flow.
+
+    Returns the Speechify item URL on success.
+    """
+    path = _validate_file_path(Path(path))
+
+    async with async_new_page() as page:
+        await _init_speechify_page(page)
+
+        if debug:
+            await _save_screenshot(page, "file-01-page-loaded")
+
+        await page.locator('[data-testid="sidebar-import-button"]').click()
+        await page.wait_for_timeout(600)
+
+        if debug:
+            await _save_screenshot(page, "file-02-new-menu")
+
+        # Selectors for the Import-file menu item are best-effort: Speechify
+        # has not stabilized data-testids for this entry. The screenshot
+        # walkthrough (`speechify-add debug`) can be used to harvest the live
+        # one if these stop matching.
+        async with page.expect_file_chooser(timeout=10_000) as fc_info:
+            await _click_first_visible(page, [
+                '[data-testid="library-menu-item-import-file"]',
+                '[data-testid="library-menu-item-upload-file"]',
+                '[data-testid="library-menu-item-upload"]',
+                '[data-testid="library-menu-item-import"]',
+                '[data-testid="library-menu-item-file"]',
+                '[role="menuitem"]:has-text("Import file")',
+                '[role="menuitem"]:has-text("Upload file")',
+                '[role="menuitem"]:has-text("Import")',
+                '[role="menuitem"]:has-text("Upload")',
+            ], step="import-file menu item", timeout=8_000)
+        chooser = await fc_info.value
+        await chooser.set_files(str(path))
+
+        if debug:
+            await _save_screenshot(page, "file-03-after-set-files")
+
+        if title:
+            try:
+                title_input = await _find_first_visible(page, [
+                    'input[placeholder="Title"]',
+                    'input[placeholder*="title"]',
+                    'input[name="title"]',
+                    'input[placeholder="Optional"]',
+                ], step="title input (optional)", timeout=2_000)
+                await title_input.fill(title)
+            except _StepSkipped:
+                pass
+
+        try:
+            await _click_first_visible(page, [
+                '[data-testid="add-file-save-button"]',
+                'button:has-text("Save File")',
+                'button:has-text("Save")',
+                'button:has-text("Import")',
+                'button:has-text("Upload")',
+                'button[type="submit"]',
+            ], step="save-file button (optional)", timeout=3_000)
+        except _StepSkipped:
+            # Some flows auto-submit on file selection.
+            pass
+
+        # PDF/EPUB processing can take longer than text — bump the timeout.
+        return await _wait_for_item_redirect(page, timeout_seconds=120)
+
+
+async def _wait_for_item_redirect(page, timeout_seconds: int) -> str:
+    """Poll page.url once per second for `/item/<uuid>` and return it."""
+    for _ in range(timeout_seconds):
+        await page.wait_for_timeout(1_000)
+        if "/item/" in page.url:
+            return page.url
+    raise RuntimeError(
+        f"Timed out waiting for Speechify to process the upload. "
+        f"Final URL: {page.url}"
+    )
 
 
 async def delete_item(item_id: str, debug: bool = False) -> None:

--- a/speechify_add/cli.py
+++ b/speechify_add/cli.py
@@ -12,6 +12,7 @@ Usage:
 import asyncio
 import re
 import sys
+from pathlib import Path
 
 import click
 import httpx
@@ -257,6 +258,31 @@ def _collect_text(file_path, from_stdin) -> str:
 async def _add_text(content: str, title: str) -> str:
     from . import browser
     return await browser.add_text(content, title=title)
+
+
+# ---------------------------------------------------------------------------
+# file command
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=str))
+@click.option("--title", "-t", default="",
+              help="Title hint (best-effort; Speechify may use the file's own metadata)")
+def file(path, title):
+    """Upload a file (.pdf/.epub/.html/.htm/.txt) to your Speechify library.
+
+    Returns the Speechify document URL on success.
+
+    Example:
+      speechify-add file article.pdf -t "On Re-reading LOTR"
+    """
+    from . import browser
+    try:
+        doc_url = _run(browser.add_file(Path(path), title=title))
+        click.echo(doc_url)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/speechify_add/file_upload_live_test.py
+++ b/speechify_add/file_upload_live_test.py
@@ -1,0 +1,86 @@
+"""
+Live end-to-end test for file upload.
+
+Uploads a uniquely-named text file to a real Speechify account, verifies the
+item appears in the library, then deletes it. Cleanup runs even if the test
+body fails.
+
+Run with:
+    pytest -m live speechify_add/file_upload_live_test.py
+
+Requirements:
+  - `speechify-add auth setup` has been run
+  - chrome-hub is reachable
+  - Network access to Speechify
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+import speechify_add
+from speechify_add import api, verify
+
+_ITEM_UUID_RE = re.compile(
+    r"/item/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+    re.IGNORECASE,
+)
+
+
+def _extract_item_uuid(item_url: str) -> str:
+    m = _ITEM_UUID_RE.search(item_url)
+    if not m:
+        raise AssertionError(
+            f"upload_file did not return a /item/<uuid> URL. Got: {item_url!r}"
+        )
+    return m.group(1)
+
+
+@pytest.mark.live
+def test_upload_file_round_trip(tmp_path):
+    """Upload a TXT file, verify it lands in the library, then delete it.
+
+    The unique title (timestamp-based) ensures the search match isn't ambiguous
+    against pre-existing library items.
+
+    Cost/time: ~30-90s. Hits real Speechify infra.
+    """
+    title = f"speechify-add live test {int(time.time())}"
+    body = (
+        f"# {title}\n\n"
+        "This is a test document uploaded by the speechify-add test suite. "
+        "It should be deleted automatically when the test exits.\n"
+    )
+    src = tmp_path / "speechify-add-live-test.txt"
+    src.write_text(body, encoding="utf-8")
+
+    item_url: str | None = None
+    try:
+        item_url = speechify_add.upload_file(src, title=title)
+        assert item_url, "upload_file returned an empty URL"
+        item_uuid = _extract_item_uuid(item_url)
+
+        # Give Speechify's indexer a moment to surface the new item in search.
+        time.sleep(5)
+
+        import asyncio
+        results = asyncio.run(verify.search_library(title))
+        matches = [r for r in results if title in r.get("title", "")]
+        assert matches, (
+            f"Uploaded item not found in library search for {title!r}. "
+            f"upload_file returned {item_url!r}; search returned {results!r}."
+        )
+    finally:
+        if item_url:
+            try:
+                uuid = _extract_item_uuid(item_url)
+                import asyncio
+                asyncio.run(api.delete_item(uuid))
+            except Exception as cleanup_err:  # noqa: BLE001
+                pytest.fail(
+                    f"Cleanup failed for {item_url!r}: {cleanup_err}. "
+                    "You may need to delete this item manually."
+                )

--- a/speechify_add/file_upload_test.py
+++ b/speechify_add/file_upload_test.py
@@ -1,14 +1,17 @@
 """
-Tests for file-upload feature: validation helpers and public API surface.
+Tests for file-upload feature: validation helpers, public API surface, and CLI.
 
 These are pure-logic tests — no browser, no network.
 """
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
 
 import speechify_add
 from speechify_add.browser import SUPPORTED_FILE_EXTS, _validate_file_path
+from speechify_add.cli import cli
 
 
 class TestValidateFilePath:
@@ -88,3 +91,95 @@ class TestUploadFileAcceptsStrAndPath:
         p.write_text("x")
         with pytest.raises(ValueError, match="Unsupported file type"):
             speechify_add.upload_file(p)
+
+
+def _drive_coroutine(coro):
+    """Run a non-awaiting mock coroutine to completion without touching asyncio.
+
+    The CLI's `_run` is normally `asyncio.run`, which mutates the global event
+    loop and interferes with other tests that use `asyncio.get_event_loop()`.
+    For unit tests where `add_file` is mocked to a synchronous-bodied
+    `async def`, we can drive the coroutine manually.
+    """
+    try:
+        coro.send(None)
+    except StopIteration as si:
+        return si.value
+    raise AssertionError("mock coroutine did not complete on first send")
+
+
+class TestFileCLICommand:
+    """CLI: speechify-add file <path> --title <title>."""
+
+    def _make_pdf(self, tmp_path):
+        p = tmp_path / "x.pdf"
+        p.write_bytes(b"%PDF-1.4\n")
+        return p
+
+    def test_help_lists_file_command(self):
+        result = CliRunner().invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "file" in result.output
+
+    def test_file_help_describes_supported_types(self):
+        result = CliRunner().invoke(cli, ["file", "--help"])
+        assert result.exit_code == 0
+        for ext in (".pdf", ".epub", ".html", ".txt"):
+            assert ext in result.output
+
+    def test_missing_path_exits_with_click_error(self, tmp_path):
+        result = CliRunner().invoke(cli, ["file", str(tmp_path / "nope.pdf")])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output.lower()
+
+    def test_directory_path_rejected_by_click(self, tmp_path):
+        d = tmp_path / "sub"
+        d.mkdir()
+        result = CliRunner().invoke(cli, ["file", str(d)])
+        assert result.exit_code != 0
+
+    def test_happy_path_prints_returned_url(self, tmp_path):
+        pdf = self._make_pdf(tmp_path)
+        fake_url = "https://app.speechify.com/item/abc-123"
+
+        async def fake_add_file(path, title=""):
+            return fake_url
+
+        with patch("speechify_add.browser.add_file", side_effect=fake_add_file), \
+             patch("speechify_add.cli._run", _drive_coroutine):
+            result = CliRunner().invoke(cli, ["file", str(pdf)])
+
+        assert result.exit_code == 0
+        assert fake_url in result.output
+
+    def test_title_flag_forwarded_to_add_file(self, tmp_path):
+        pdf = self._make_pdf(tmp_path)
+        captured = {}
+
+        async def fake_add_file(path, title=""):
+            captured["path"] = path
+            captured["title"] = title
+            return "https://app.speechify.com/item/uuid"
+
+        with patch("speechify_add.browser.add_file", side_effect=fake_add_file), \
+             patch("speechify_add.cli._run", _drive_coroutine):
+            result = CliRunner().invoke(
+                cli, ["file", str(pdf), "-t", "My Title"]
+            )
+
+        assert result.exit_code == 0
+        assert captured["title"] == "My Title"
+        assert Path(captured["path"]) == pdf
+
+    def test_browser_error_exits_1_with_stderr(self, tmp_path):
+        pdf = self._make_pdf(tmp_path)
+
+        async def fake_add_file(path, title=""):
+            raise RuntimeError("Speechify said no")
+
+        with patch("speechify_add.browser.add_file", side_effect=fake_add_file), \
+             patch("speechify_add.cli._run", _drive_coroutine):
+            result = CliRunner().invoke(cli, ["file", str(pdf)])
+
+        assert result.exit_code == 1
+        assert "Error: Speechify said no" in result.output

--- a/speechify_add/file_upload_test.py
+++ b/speechify_add/file_upload_test.py
@@ -1,0 +1,90 @@
+"""
+Tests for file-upload feature: validation helpers and public API surface.
+
+These are pure-logic tests — no browser, no network.
+"""
+from pathlib import Path
+
+import pytest
+
+import speechify_add
+from speechify_add.browser import SUPPORTED_FILE_EXTS, _validate_file_path
+
+
+class TestValidateFilePath:
+    def test_accepts_pdf(self, tmp_path):
+        p = tmp_path / "a.pdf"
+        p.write_bytes(b"%PDF-1.4\n")
+        assert _validate_file_path(p) == p
+
+    @pytest.mark.parametrize("ext", [".pdf", ".epub", ".html", ".htm", ".txt"])
+    def test_accepts_each_supported_extension(self, tmp_path, ext):
+        p = tmp_path / f"file{ext}"
+        p.write_text("x")
+        assert _validate_file_path(p) == p
+
+    @pytest.mark.parametrize("ext", [".PDF", ".Epub", ".HTML"])
+    def test_extension_check_is_case_insensitive(self, tmp_path, ext):
+        p = tmp_path / f"file{ext}"
+        p.write_text("x")
+        assert _validate_file_path(p) == p
+
+    def test_rejects_unsupported_extension(self, tmp_path):
+        p = tmp_path / "a.docx"
+        p.write_text("x")
+        with pytest.raises(ValueError, match="Unsupported file type"):
+            _validate_file_path(p)
+
+    def test_error_lists_supported_extensions(self, tmp_path):
+        p = tmp_path / "a.docx"
+        p.write_text("x")
+        with pytest.raises(ValueError) as exc_info:
+            _validate_file_path(p)
+        msg = str(exc_info.value)
+        for ext in SUPPORTED_FILE_EXTS:
+            assert ext in msg
+
+    def test_rejects_missing_file(self, tmp_path):
+        p = tmp_path / "missing.pdf"
+        with pytest.raises(FileNotFoundError):
+            _validate_file_path(p)
+
+    def test_rejects_directory(self, tmp_path):
+        d = tmp_path / "subdir.pdf"
+        d.mkdir()
+        with pytest.raises(ValueError, match="Not a file"):
+            _validate_file_path(d)
+
+
+class TestPublicAPISurface:
+    def test_upload_text_is_exported(self):
+        assert callable(speechify_add.upload_text)
+
+    def test_upload_file_is_exported(self):
+        assert callable(speechify_add.upload_file)
+
+    def test_upload_url_is_exported(self):
+        assert callable(speechify_add.upload_url)
+
+    def test_all_lists_public_api(self):
+        assert set(speechify_add.__all__) >= {
+            "upload_text", "upload_file", "upload_url"
+        }
+
+
+class TestUploadFileAcceptsStrAndPath:
+    """upload_file should accept either a str path or a Path object."""
+
+    def test_rejects_missing_path_as_str(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            speechify_add.upload_file(str(tmp_path / "nope.pdf"))
+
+    def test_rejects_missing_path_as_path(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            speechify_add.upload_file(tmp_path / "nope.pdf")
+
+    def test_rejects_unsupported_extension(self, tmp_path):
+        p = tmp_path / "a.docx"
+        p.write_text("x")
+        with pytest.raises(ValueError, match="Unsupported file type"):
+            speechify_add.upload_file(p)


### PR DESCRIPTION
## Summary
- Add `speechify-add file <path>` CLI command for uploading `.pdf` / `.epub` / `.html` / `.htm` / `.txt` via Speechify's Import-file flow on the persistent browser profile — returns the Speechify item URL.
- Promote internals to a public Python API: `upload_text`, `upload_file`, `upload_url` are now importable from `speechify_add` for downstream pipelines (medium-fetch, book-to-speechify, hn-digest, …).
- `browser.add_url` now captures the resulting `/item/<uuid>` URL when observable (best-effort: returns `""` if the redirect doesn't happen within 15s, preserving the existing fire-and-forget behavior for the CLI).

## How it works
- The Import-file menu entry's `data-testid` isn't documented; the implementation tries a list of likely selectors and falls back to text-match patterns. If Speechify rotates these, `speechify-add debug` will dump the live elements for selector recovery.
- File chooser is captured via `page.expect_file_chooser()` so we work whether the menu item triggers a hidden `<input type=\"file\">` or a native chooser dialog.
- `--title` is best-effort: if the import dialog exposes a title field we fill it; otherwise Speechify extracts the title from the file's own metadata (PDFs especially).

## Test plan
- [x] Pure-logic tests for path validation (`pdf` / `epub` / `html` / `htm` / `txt`, case-insensitive, missing file, directory, unsupported extension)
- [x] Tests for public API surface (`upload_text`, `upload_file`, `upload_url` exported and callable; `__all__` lists them)
- [x] Full non-live test suite passes (232 passed, 14 deselected)
- [x] **Live round-trip test** (`pytest -m live`): generates a uniquely-titled TXT file, uploads via `upload_file`, asserts the item appears in library search, then deletes it via `api.delete_item`. Cleanup runs in `finally` so a failed assertion still removes the artifact.

## Related issues
Closes #36

Generated with [Claude Code](https://claude.com/claude-code)