### PR TITLE
fix: switch paste-text entry to new add-text-button toolbar (#41)

### DIFF
--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -24,11 +24,26 @@ SCREENSHOT_DIR = Path.home() / ".config" / "speechify-add" / "debug-screenshots"
 
 SUPPORTED_FILE_EXTS = frozenset({".pdf", ".epub", ".html", ".htm", ".txt"})
 
-# Wait this long for the "Paste Text" menu item to become visible. The
-# implicit Playwright default (30s) was too tight: under load Speechify
-# rotates DOM and the menu item appears intermittently — see issue #39.
+# Wait this long for the "Paste Text" menu item to become visible (legacy
+# UI). The implicit Playwright default (30s) was too tight under load —
+# see issue #39.
 PASTE_TEXT_MENU_TIMEOUT_MS = 60_000
 
+# How long to wait for the new-UI toolbar button before falling back to
+# the legacy "+ New" menu flow. Short — if it's there, it's there.
+ADD_TEXT_BUTTON_TIMEOUT_MS = 5_000
+
+# New Speechify Library UI (issue #41): direct top-bar buttons replace
+# the old "+ New → Paste Text" dropdown. `add-text-button` is "Create
+# Note" and opens the same paste-text modal we already drive.
+ADD_TEXT_BUTTON_SELECTORS = [
+    '[data-testid="add-text-button"]',
+    'button:has-text("Create Note")',
+]
+
+# Legacy Speechify UI: "+ New" sidebar button opens a dropdown menu,
+# then a menu item opens the paste-text modal. Kept as a fallback during
+# rollout — sessions still on the old UI will hit this path.
 PASTE_TEXT_MENU_SELECTORS = [
     '[data-testid="library-menu-item-paste-text"]',
     '[role="menuitem"]:has-text("Paste Text")',
@@ -576,36 +591,68 @@ async def _add_text_with_cleanup(
     return doc_url
 
 
-async def _do_add_text(page, text: str, title: str = "", debug: bool = False) -> str:
-    """Drive the Paste Text modal end-to-end and return the /item/ URL.
+async def _open_paste_text_modal(page, debug: bool = False) -> str:
+    """Open the paste-text modal by whichever entry point Speechify is
+    serving this session. Returns the entry name used (``"toolbar"`` or
+    ``"menu"``). Raises ``_StepSkipped`` if neither flow finds the entry.
 
-    Raises ``RuntimeError`` if the menu item never appears or Speechify
-    never redirects to /item/<uuid> within the timeout. On menu-item
-    failure, dumps the page screenshot + HTML so we can see what changed.
+    Issue #41: Speechify is rolling out a redesigned Library UI. The new
+    flow has a top-bar ``[data-testid="add-text-button"]`` ("Create
+    Note") that opens the modal directly — no "+ New" step. The legacy
+    flow ("+ New" sidebar → ``library-menu-item-paste-text``) is kept
+    as a fallback for sessions still on the old UI during rollout.
     """
-    if debug:
-        await _save_screenshot(page, "text-01-before-new-menu")
-
-    # Open "New" menu
-    await page.locator('[data-testid="sidebar-import-button"]').click()
-    await page.wait_for_timeout(600)
-
-    # Click "Paste Text" — was previously a single bare locator.click() that
-    # used Playwright's implicit 30s timeout. Issue #39: this click times
-    # out roughly once per 20 uploads, and the retry path produced corrupt
-    # items. Use the same fallback-selector helper used elsewhere, with a
-    # generous timeout, and dump the DOM on failure.
+    # New UI first: a quick visibility check, then a single click.
     try:
         await _click_first_visible(
             page,
-            PASTE_TEXT_MENU_SELECTORS,
-            step="paste-text menu item",
-            timeout=PASTE_TEXT_MENU_TIMEOUT_MS,
+            ADD_TEXT_BUTTON_SELECTORS,
+            step="add-text toolbar button",
+            timeout=ADD_TEXT_BUTTON_TIMEOUT_MS,
         )
+        log.debug("paste-text: opened via add-text-button (new UI)")
+        return "toolbar"
     except _StepSkipped:
-        await _dump_failure(page, "paste-text-menu")
+        log.debug(
+            "paste-text: add-text-button not visible after %.1fs; "
+            "trying legacy '+ New' menu flow",
+            ADD_TEXT_BUTTON_TIMEOUT_MS / 1000,
+        )
+
+    # Legacy UI: open "+ New" dropdown, then click the Paste Text item.
+    # Only do the "+ New" click in this branch — on the new UI it opens
+    # an unrelated dialog (`aria-haspopup="dialog"`) which we don't want.
+    await page.locator('[data-testid="sidebar-import-button"]').click()
+    await page.wait_for_timeout(600)
+    await _click_first_visible(
+        page,
+        PASTE_TEXT_MENU_SELECTORS,
+        step="paste-text menu item",
+        timeout=PASTE_TEXT_MENU_TIMEOUT_MS,
+    )
+    log.debug("paste-text: opened via library-menu-item-paste-text (legacy UI)")
+    return "menu"
+
+
+async def _do_add_text(page, text: str, title: str = "", debug: bool = False) -> str:
+    """Drive the Paste Text modal end-to-end and return the /item/ URL.
+
+    Raises ``RuntimeError`` if neither entry point opens the modal or
+    Speechify never redirects to /item/<uuid> within the timeout. On
+    entry-point failure, dumps the page screenshot + HTML so we can see
+    what changed.
+    """
+    if debug:
+        await _save_screenshot(page, "text-01-before-entry")
+
+    try:
+        await _open_paste_text_modal(page, debug=debug)
+    except _StepSkipped:
+        await _dump_failure(page, "paste-text-entry")
         raise RuntimeError(
-            f"Paste Text menu item not visible after "
+            f"Could not open the Paste Text modal — neither the "
+            f"add-text-button toolbar (new UI) nor the '+ New' menu "
+            f"(legacy UI) responded within "
             f"{PASTE_TEXT_MENU_TIMEOUT_MS // 1000}s. DOM dumped to "
             f"{SCREENSHOT_DIR}. Speechify's UI may have changed."
         )

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -591,7 +591,7 @@ async def _add_text_with_cleanup(
     return doc_url
 
 
-async def _open_paste_text_modal(page, debug: bool = False) -> str:
+async def _open_paste_text_modal(page) -> str:
     """Open the paste-text modal by whichever entry point Speechify is
     serving this session. Returns the entry name used (``"toolbar"`` or
     ``"menu"``). Raises ``_StepSkipped`` if neither flow finds the entry.
@@ -646,7 +646,7 @@ async def _do_add_text(page, text: str, title: str = "", debug: bool = False) ->
         await _save_screenshot(page, "text-01-before-entry")
 
     try:
-        await _open_paste_text_modal(page, debug=debug)
+        await _open_paste_text_modal(page)
     except _StepSkipped:
         await _dump_failure(page, "paste-text-entry")
         raise RuntimeError(

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -16,9 +16,13 @@ from speechify_add.browser import (
     _find_first_visible,
     _click_first_visible,
     _maybe_delete_partial_item,
+    _open_paste_text_modal,
     _verify_item_playable,
     _StepSkipped,
     BrowserSession,
+    ADD_TEXT_BUTTON_SELECTORS,
+    ADD_TEXT_BUTTON_TIMEOUT_MS,
+    PASTE_TEXT_MENU_SELECTORS,
     PASTE_TEXT_MENU_TIMEOUT_MS,
 )
 
@@ -767,3 +771,105 @@ class TestPasteTextMenuTimeout:
         """Issue #39: Playwright's implicit 30s click timeout was too tight.
         Ensure we use a generous explicit timeout."""
         assert PASTE_TEXT_MENU_TIMEOUT_MS >= 60_000
+
+
+# ---------------------------------------------------------------------------
+# 14. _open_paste_text_modal — entry-point selection (issue #41)
+# ---------------------------------------------------------------------------
+
+class TestOpenPasteTextModal:
+    """The new Speechify Library UI replaces the "+ New" dropdown with a
+    direct top-bar button. We try the new selector first; if it isn't
+    visible, we fall back to the legacy "+ New" → menu flow.
+    """
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_new_ui_first_skips_sidebar_click(self):
+        """When add-text-button is visible, we click it directly and
+        do NOT touch the legacy '+ New' sidebar button."""
+        page = MagicMock()
+        page.wait_for_timeout = AsyncMock()
+        sidebar_clicked = []
+
+        def locator_side_effect(selector):
+            m = MagicMock()
+            m.click = AsyncMock(
+                side_effect=lambda: sidebar_clicked.append(selector),
+            )
+            m.wait_for = AsyncMock()
+            m.first = m
+            return m
+
+        page.locator.side_effect = locator_side_effect
+
+        result = self._run(_open_paste_text_modal(page))
+        assert result == "toolbar"
+        # Must not have clicked the legacy "+ New" sidebar button
+        assert not any("sidebar-import-button" in s for s in sidebar_clicked)
+
+    def test_falls_back_to_legacy_when_toolbar_missing(self):
+        """When add-text-button never appears, we click '+ New' and
+        then the menu item — preserving compatibility with the old UI."""
+        page = MagicMock()
+        page.wait_for_timeout = AsyncMock()
+
+        clicked = []
+
+        def locator_side_effect(selector):
+            m = MagicMock()
+            # Hide all add-text-* selectors (new UI)
+            if any(s in selector for s in ("add-text-button", "Create Note")):
+                m.wait_for = AsyncMock(side_effect=Exception("not visible"))
+            else:
+                m.wait_for = AsyncMock()
+            m.click = AsyncMock(side_effect=lambda: clicked.append(selector))
+            m.first = m
+            return m
+
+        page.locator.side_effect = locator_side_effect
+
+        result = self._run(_open_paste_text_modal(page))
+        assert result == "menu"
+        assert any("sidebar-import-button" in s for s in clicked), \
+            f"Expected '+ New' click in legacy fallback, got: {clicked}"
+
+    def test_raises_step_skipped_when_neither_works(self):
+        """Both new and legacy entry points missing → raise _StepSkipped
+        so the caller dumps the DOM and surfaces a clear error."""
+        page = MagicMock()
+        page.wait_for_timeout = AsyncMock()
+
+        def locator_side_effect(selector):
+            m = MagicMock()
+            # Sidebar click works (no error), but every paste-text
+            # selector is invisible.
+            if "sidebar-import-button" in selector:
+                m.click = AsyncMock()
+                m.wait_for = AsyncMock()
+            else:
+                m.wait_for = AsyncMock(side_effect=Exception("not visible"))
+                m.click = AsyncMock()
+            m.first = m
+            return m
+
+        page.locator.side_effect = locator_side_effect
+
+        with pytest.raises(_StepSkipped):
+            self._run(_open_paste_text_modal(page))
+
+
+class TestEntryPointConstants:
+    def test_add_text_selectors_have_data_testid_first(self):
+        """The new-UI testid is the most reliable signal — try it first."""
+        assert ADD_TEXT_BUTTON_SELECTORS[0] == '[data-testid="add-text-button"]'
+
+    def test_add_text_timeout_is_short(self):
+        """The toolbar visibility check must fail fast so the legacy
+        fallback doesn't sit on it for 60s on every old-UI session."""
+        assert ADD_TEXT_BUTTON_TIMEOUT_MS <= 10_000
+
+    def test_paste_text_menu_selectors_kept(self):
+        """Legacy menu selectors must still be present for fallback."""
+        assert any("library-menu-item-paste-text" in s for s in PASTE_TEXT_MENU_SELECTORS)


### PR DESCRIPTION
## Summary

Fixes #41. Speechify replaced the "+ New" sidebar dropdown menu with direct top-bar toolbar buttons in the redesigned Library UI. The old `[data-testid="library-menu-item-paste-text"]` selector no longer exists; `sidebar-import-button` now opens a modal dialog (`aria-haspopup="dialog"`) instead of a dropdown menu. **This is what was actually causing the 30s click timeouts attributed to flakiness in #39** — not a race condition, just the wrong selector.

- `[data-testid="add-text-button"]` ("Create Note") is now the primary entry. It opens the same modal we already drive (title input + textarea + `add-text-save-button`), so the rest of the flow is unchanged.
- The legacy "+ New" → menu flow is kept as a fallback for sessions still on the old UI during rollout. We only click `sidebar-import-button` in the legacy branch — on the new UI it opens an unrelated dialog we don't want.
- Fail fast (5s) on the new selector so old-UI sessions don't pay a 60s penalty before falling through.

## Test plan

- [x] `pytest -m "not live"` — 265 passed (up from 259; +6 new tests covering `_open_paste_text_modal` selecting toolbar over menu, falling back to legacy menu when toolbar missing, raising when neither works, plus invariants on the constants).
- [x] Live verified against current Speechify: uploaded a small synthetic article via the new path in 10s and got a real `/item/<uuid>`. Log shows `paste-text: opened via add-text-button (new UI)` and the item rendered correctly. Test item cleaned up via API.
- [ ] Tomorrow morning's 07:50 dailybrief run should show no `Locator.click: Timeout 30000ms exceeded` warnings in the journal — that was the previous symptom.

## Notes

- The delete flow uses different selectors that may also have been redesigned (`speechify-add delete --mode browser` failed during my live test). Out of scope for this PR; tracked separately if it surfaces.
- #42 covers the dead `_verify_item_playable` overlay check from #40 — once #41 lands, the timeout-retry path should disappear entirely, so the verify check probably becomes irrelevant.

Generated with [Claude Code](https://claude.com/claude-code)