### PR TITLE
refactor: remove dead _verify_item_playable overlay check (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cat summary.txt | speechify-add text --stdin -t "Daily Summary"
 
 Returns the Speechify document URL on success. Handles large files (tested up to 700K chars).
 
-After the upload completes, `speechify-add` re-fetches the item page and confirms it isn't showing the "Oops, something went wrong" overlay before returning. If the item is in a half-state, the corrupt item is deleted and the command exits non-zero so a caller's retry path can run cleanly instead of getting back a URL that looks fine but is unplayable on mobile (issue #39).
+If the upload flow fails mid-stream and the page is already on `/item/<uuid>`, the partial item is deleted before the error is re-raised so retries don't accumulate orphans in the library.
 
 ### Add a file (PDF / EPUB / HTML / TXT)
 

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -52,14 +52,6 @@ PASTE_TEXT_MENU_SELECTORS = [
     'button:has-text("Paste text")',
 ]
 
-# Phrases Speechify renders inside a half-state item — confirmed user-facing
-# on mobile after a flaky paste-text upload (issue #39).
-ITEM_ERROR_PHRASES = (
-    "something went wrong",
-    "try again later",
-    "Oops",
-)
-
 _ITEM_ID_RE = re.compile(
     r"/item/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
     re.IGNORECASE,
@@ -198,10 +190,9 @@ async def add_text(text: str, title: str = "", debug: bool = False) -> str:
     Add raw text to Speechify via the "Paste Text" UI flow.
     Returns the Speechify document URL (e.g. https://app.speechify.com/item/<uuid>).
 
-    Verifies the resulting item is playable before returning so callers
-    don't get a URL that looks fine but renders "Oops, something went
-    wrong" on mobile. On any failure mid-flow, attempts to delete a
-    partial item if one was created (issue #39).
+    On any failure mid-flow, attempts to delete a partial item if one
+    was already created (URL is on /item/<uuid>) before re-raising
+    (issue #39).
     """
     async with async_new_page() as page:
         await _init_speechify_page(page)
@@ -553,42 +544,22 @@ async def _find_first_visible(page, selectors, step, timeout=5_000):
 
 # ---------------------------------------------------------------------------
 # Paste-text upload internals (shared by BrowserSession.add_text and the
-# standalone add_text). Pulled out so the resilience + verification +
-# orphan-cleanup logic isn't duplicated in two places (issue #39).
+# standalone add_text). Pulled out so the resilience + orphan-cleanup
+# logic isn't duplicated in two places (issue #39).
 # ---------------------------------------------------------------------------
 
 async def _add_text_with_cleanup(
     page, text: str, title: str, debug: bool
 ) -> str:
-    """Run ``_do_add_text`` followed by ``_verify_item_playable``, deleting
-    any partial / half-state item before re-raising on failure (issue #39).
-    Shared by ``BrowserSession.add_text`` and the standalone ``add_text``.
+    """Run ``_do_add_text``, deleting any partial item before re-raising
+    on failure (issue #39). Shared by ``BrowserSession.add_text`` and the
+    standalone ``add_text``.
     """
     try:
-        doc_url = await _do_add_text(page, text, title=title, debug=debug)
+        return await _do_add_text(page, text, title=title, debug=debug)
     except Exception:
         await _maybe_delete_partial_item(page, debug=debug)
         raise
-
-    try:
-        await _verify_item_playable(page, doc_url, debug=debug)
-    except Exception:
-        item_id = _extract_item_id(doc_url)
-        if item_id:
-            log.warning(
-                "Speechify item %s failed verification; deleting half-state item",
-                item_id,
-            )
-            try:
-                await _perform_delete(page, item_id, debug=debug)
-            except Exception as cleanup_err:
-                log.warning(
-                    "Cleanup of half-state item %s failed: %s",
-                    item_id, cleanup_err,
-                )
-        raise
-
-    return doc_url
 
 
 async def _open_paste_text_modal(page) -> str:
@@ -693,39 +664,6 @@ async def _do_add_text(page, text: str, title: str = "", debug: bool = False) ->
         "Timed out waiting for Speechify to process the text. "
         f"Final URL: {page.url}"
     )
-
-
-async def _verify_item_playable(page, item_url: str, debug: bool = False) -> None:
-    """Confirm the Speechify item at ``item_url`` is in a playable state.
-
-    Issue #39: a flaky paste-text upload occasionally produces an item URL
-    that looks valid but renders "Oops, something went wrong. Try again
-    later." in the mobile app. This helper navigates to the item page,
-    waits for it to render, and raises ``RuntimeError`` if the error
-    overlay is present — letting the caller's retry path run cleanly
-    instead of returning a corrupt URL.
-    """
-    item_id = _extract_item_id(item_url)
-    if not item_id:
-        raise RuntimeError(f"Not a Speechify item URL: {item_url}")
-
-    expected = f"https://app.speechify.com/item/{item_id}"
-    if not page.url.startswith(expected):
-        await page.goto(expected, wait_until="load", timeout=30_000)
-    await page.wait_for_timeout(2_000)
-
-    if debug:
-        await _save_screenshot(page, "verify-01-item-page")
-
-    for phrase in ITEM_ERROR_PHRASES:
-        count = await page.locator(f"text=/{re.escape(phrase)}/i").count()
-        if count > 0:
-            await _dump_failure(page, f"verify-error-overlay-{item_id}")
-            raise RuntimeError(
-                f"Speechify item {item_id} shows error overlay "
-                f"({phrase!r}) — half-state upload, will not be playable. "
-                f"URL: {item_url}"
-            )
 
 
 async def _maybe_delete_partial_item(page, debug: bool = False) -> None:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -17,7 +17,6 @@ from speechify_add.browser import (
     _click_first_visible,
     _maybe_delete_partial_item,
     _open_paste_text_modal,
-    _verify_item_playable,
     _StepSkipped,
     BrowserSession,
     ADD_TEXT_BUTTON_SELECTORS,
@@ -587,66 +586,6 @@ class TestExtractItemId:
 
 
 # ---------------------------------------------------------------------------
-# 10. _verify_item_playable — issue #39 core check
-# ---------------------------------------------------------------------------
-
-class TestVerifyItemPlayable:
-    _UUID = "cff1772b-7603-4d46-966c-97b4b4566443"
-    _ITEM_URL = f"https://app.speechify.com/item/{_UUID}"
-
-    def _make_page_with_overlay_count(self, count: int):
-        page = _make_page(url=self._ITEM_URL)
-        page.goto = AsyncMock()
-        page.wait_for_timeout = AsyncMock()
-        loc = MagicMock()
-        loc.count = AsyncMock(return_value=count)
-        page.locator = MagicMock(return_value=loc)
-        page.screenshot = AsyncMock()
-        page.content = AsyncMock(return_value="<html></html>")
-        return page
-
-    def test_raises_when_error_overlay_present(self):
-        """If 'something went wrong' is on the item page, the item is broken."""
-        page = self._make_page_with_overlay_count(1)
-        with pytest.raises(RuntimeError, match="error overlay"):
-            asyncio.get_event_loop().run_until_complete(
-                _verify_item_playable(page, self._ITEM_URL)
-            )
-
-    def test_does_not_raise_when_overlay_absent(self):
-        """No error overlay means the item is considered playable."""
-        page = self._make_page_with_overlay_count(0)
-        # Must not raise
-        asyncio.get_event_loop().run_until_complete(
-            _verify_item_playable(page, self._ITEM_URL)
-        )
-
-    def test_raises_when_url_is_not_item_url(self):
-        """Reject URLs that don't contain a Speechify item UUID."""
-        page = self._make_page_with_overlay_count(0)
-        with pytest.raises(RuntimeError, match="Not a Speechify item URL"):
-            asyncio.get_event_loop().run_until_complete(
-                _verify_item_playable(page, "https://app.speechify.com/library")
-            )
-
-    def test_navigates_to_item_when_page_elsewhere(self):
-        """If page is not on the item URL, we navigate there before checking."""
-        page = _make_page(url="https://app.speechify.com/library")
-        page.goto = AsyncMock()
-        page.wait_for_timeout = AsyncMock()
-        loc = MagicMock()
-        loc.count = AsyncMock(return_value=0)
-        page.locator = MagicMock(return_value=loc)
-
-        asyncio.get_event_loop().run_until_complete(
-            _verify_item_playable(page, self._ITEM_URL)
-        )
-        page.goto.assert_awaited_once()
-        called_url = page.goto.call_args[0][0]
-        assert self._UUID in called_url
-
-
-# ---------------------------------------------------------------------------
 # 11. _maybe_delete_partial_item — orphan cleanup
 # ---------------------------------------------------------------------------
 
@@ -684,37 +623,12 @@ class TestMaybeDeletePartialItem:
 
 
 # ---------------------------------------------------------------------------
-# 12. BrowserSession.add_text — verify-and-cleanup path (issue #39)
+# 12. BrowserSession.add_text — orphan-cleanup path (issue #39)
 # ---------------------------------------------------------------------------
 
 class TestAddTextVerificationCleanup:
     _UUID = "cff1772b-7603-4d46-966c-97b4b4566443"
     _ITEM_URL = f"https://app.speechify.com/item/{_UUID}"
-
-    def test_verify_failure_triggers_delete_and_reraise(self):
-        """If verification raises, the corrupt item is deleted and the
-        original error is re-raised so the caller's retry runs cleanly."""
-        async def run():
-            session = BrowserSession()
-            page = _make_page(url=self._ITEM_URL)
-            session._page = page
-
-            with patch(
-                "speechify_add.browser._do_add_text",
-                AsyncMock(return_value=self._ITEM_URL),
-            ), patch(
-                "speechify_add.browser._verify_item_playable",
-                AsyncMock(side_effect=RuntimeError("error overlay shown")),
-            ), patch(
-                "speechify_add.browser._perform_delete", AsyncMock()
-            ) as pd:
-                with pytest.raises(RuntimeError, match="error overlay"):
-                    await session.add_text("hello", title="Hi")
-
-            pd.assert_awaited_once()
-            assert pd.await_args[0][1] == self._UUID
-
-        asyncio.get_event_loop().run_until_complete(run())
 
     def test_mid_flow_failure_triggers_orphan_cleanup(self):
         """If the upload itself fails while page is on /item/<uuid>, the


### PR DESCRIPTION
## Summary

Closes #42. PR #40 added `_verify_item_playable` to detect half-state Speechify items by checking the rendered item page for "Oops" / "something went wrong" / "try again later". Probing the known-broken item from #39's reproduction (`cff1772b-7603-4d46-966c-97b4b4566443`) confirmed the web view shows **zero** occurrences of any of those phrases — the error overlay is mobile-only. The check was dead defense.

After #41 switched the entry point to `add-text-button`, the timeout-retry path that was suspected of producing half-state items shouldn't fire in normal operation anyway. Removing the verify step also saves the `wait_for_timeout(2_000)` it ran on every successful upload.

- Drop `_verify_item_playable` and `ITEM_ERROR_PHRASES`.
- Simplify `_add_text_with_cleanup` to just `_do_add_text` + `_maybe_delete_partial_item` on failure (the genuinely-useful piece of #40 — orphan cleanup when the page is left on `/item/<uuid>`).
- Drop the obsolete `TestVerifyItemPlayable` suite (4 tests) and `test_verify_failure_triggers_delete_and_reraise`.
- Update README to reflect the new (smaller) post-upload contract.

## Test plan

- [x] `pytest -m "not live"` — 260 passed (down from 265, 5 obsolete tests removed).
- [x] Live verified: uploaded a synthetic article via the current code path in 11.5s, got `https://app.speechify.com/item/f2c04c41-3665-4507-95c9-f72da1875240`, cleaned up via API delete. Module-level guard asserts confirmed `_verify_item_playable` and `ITEM_ERROR_PHRASES` are gone.
- [ ] Tomorrow morning's 07:50 dailybrief should still upload 20/20 to Speechify successfully (and faster, since the per-upload 2s verify wait is gone).

Generated with [Claude Code](https://claude.com/claude-code)