### PR TITLE
fix: speechify-add verify in new Library UI + URL-based mode + live roundtrip canary (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,23 @@ Uses the `archiveLibraryItem` API — no browser needed.
 
 ### Search / verify
 
-Confirm an article is in your library:
+Confirm an item is in your library:
 
 ```bash
-# Search by URL (fetches the page title automatically)
+# Direct URL/UUID check — recommended for verifying something you just uploaded.
+# Bypasses Speechify's library search (which has minutes of indexing latency
+# for fresh uploads) and goes straight to the item page.
+speechify-add verify https://app.speechify.com/item/783247eb-59c9-4ade-9027-e01f8d77d959
+speechify-add verify 783247eb-59c9-4ade-9027-e01f8d77d959
+
+# Article URL (fetches the page title and searches by it)
 speechify-add verify https://arstechnica.com/some-article/
 
-# Search by keyword
+# Free-form keyword search
 speechify-add verify "cosmic distance ladder"
 ```
+
+The search-based modes match by title substring (case-insensitive, either direction): a non-empty fuzzy result list isn't enough, the query must actually appear in at least one returned title. The URL/UUID mode is the reliable form for automation that wants to verify the upload it just did.
 
 ### Auth management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,12 @@ speechify-add = "speechify_add.cli:cli"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["speechify_add*"]
+
+[tool.pytest.ini_options]
+# Default to skipping live tests so unit-suite runs are fast and offline.
+# Run live tests explicitly with: pytest -m live
+addopts = "-m 'not live'"
+asyncio_mode = "auto"
+markers = [
+    "live: hits real external services (chrome-hub, Speechify); skipped by default",
+]

--- a/speechify_add/cli.py
+++ b/speechify_add/cli.py
@@ -295,6 +295,15 @@ _SPEECHIFY_ITEM_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Stricter form: input must be JUST a Speechify item URL or bare UUID
+# (not e.g. a sentence containing one). Used by `verify` to decide
+# between URL-based (reliable) and search-based (lossy) verification.
+_SPEECHIFY_ITEM_REF_RE = re.compile(
+    r"^(?:https?://app\.speechify\.com/item/)?"
+    r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
+    re.IGNORECASE,
+)
+
 
 def _parse_item_id(item: str) -> str:
     """Extract a Speechify item UUID from a full URL or bare UUID string."""
@@ -306,6 +315,16 @@ def _parse_item_id(item: str) -> str:
             "or a URL like https://app.speechify.com/item/<uuid>"
         )
     return m.group(1)
+
+
+def _try_parse_item_ref(s: str) -> str | None:
+    """Return the UUID if `s` is exactly a Speechify item URL or UUID.
+
+    Unlike `_parse_item_id`, returns None instead of raising so callers
+    can branch on whether the input is URL-shaped vs. a search query.
+    """
+    m = _SPEECHIFY_ITEM_REF_RE.match(s.strip())
+    return m.group(1) if m else None
 
 
 @cli.command()
@@ -345,11 +364,23 @@ async def _do_delete(item_id: str, mode: str = "browser", debug: bool = False) -
 @click.argument("query")
 def verify(query):
     """
-    Search your Speechify library and confirm an article is there.
+    Confirm an item is in your Speechify library.
 
-    QUERY can be a URL (title is fetched automatically) or any search term.
+    QUERY can be one of:
+    \b
+      * Speechify item URL or bare UUID — direct URL-based check
+        (recommended; reliable for freshly-uploaded items).
+      * Article URL — fetches the page title and searches.
+      * Free-form search text — searches the library.
+
+    Search-based modes have indexing latency: brand-new uploads can
+    take minutes to surface, so prefer the UUID/URL form when verifying
+    something you just uploaded.
 
     Examples:
+    \b
+      speechify-add verify https://app.speechify.com/item/783247eb-...
+      speechify-add verify 783247eb-59c9-4ade-9027-e01f8d77d959
       speechify-add verify https://arstechnica.com/...
       speechify-add verify "cosmic distance ladder"
     """
@@ -359,7 +390,20 @@ def verify(query):
 async def _do_verify(query: str):
     from . import verify as verify_module
 
-    # If it looks like a URL, fetch the page title to search by
+    # Speechify item URL or bare UUID → URL-based verification (issue #45).
+    # Reliable for freshly-uploaded items; the library search has
+    # ~minutes of indexing latency so a title search won't surface them.
+    item_id = _try_parse_item_ref(query)
+    if item_id:
+        click.echo(f"Verifying https://app.speechify.com/item/{item_id} ...")
+        ok, info = await verify_module.verify_item_url(item_id)
+        if ok:
+            click.echo(f"✓  {info}")
+            return
+        click.echo(f"✗  {info}", err=True)
+        raise SystemExit(1)
+
+    # If it looks like an article URL, fetch the page title to search by
     search_term = query
     if query.startswith("http"):
         click.echo(f"Fetching title for {query} ...")
@@ -386,8 +430,29 @@ async def _do_verify(query: str):
         click.echo(f"\n✗  No results found for \"{search_term}\"")
         raise SystemExit(1)
 
-    click.echo(f"\n{len(results)} result(s) found:\n")
-    for item in results:
+    # Speechify's library search is fuzzy/semantic — a non-empty result list
+    # alone isn't proof the specific item we asked about exists. Issue #45:
+    # require a title-substring match (case-insensitive, in either direction)
+    # before treating the verification as passed. Otherwise callers like
+    # dailybrief's verify-after-upload step would treat every upload as
+    # verified just because the search returned any related article.
+    needle = search_term.lower()
+    matches = [
+        item for item in results
+        if needle in item["title"].lower() or item["title"].lower() in needle
+    ]
+
+    if not matches:
+        click.echo(
+            f"\n✗  None of {len(results)} result(s) contain "
+            f"\"{search_term}\" in the title; closest fuzzy matches:\n"
+        )
+        for item in results[:5]:
+            click.echo(f"     ~  {item['title']}")
+        raise SystemExit(1)
+
+    click.echo(f"\n{len(matches)} matching result(s):\n")
+    for item in matches:
         click.echo(f"  ✓  {item['title']}")
         if item["meta"]:
             click.echo(f"     {item['meta']}")

--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -17,6 +17,41 @@ from chrome_hub import async_new_page
 log = logging.getLogger(__name__)
 
 
+# JS evaluator that extracts library-item rows from the rendered DOM.
+# Issue #45: Speechify rolled out a Library UI redesign — the old
+# `<button>` rows with inline "73% · web" innerText are gone. The new
+# rows are `<div role="button">` containing structural testids
+# (library-item-title / library-item-progress / library-item-date /
+# library-item-type). Items at 0% don't render the progress div, so
+# we synthesize "0%" for backward-compat with parse_progress_pct.
+_LIBRARY_ITEMS_JS = """
+() => {
+    const titles = document.querySelectorAll(
+        '[data-testid="library-item-title"]'
+    );
+    return Array.from(titles).map(t => {
+        const row = t.closest('[role="button"]')
+            || t.closest('button')
+            || t.parentElement;
+        const progEl = row?.querySelector(
+            '[data-testid="library-item-progress"]'
+        );
+        const dateEl = row?.querySelector(
+            '[data-testid="library-item-date"]'
+        );
+        const typeEl = row?.querySelector(
+            '[data-testid="library-item-type"]'
+        );
+        const progress = progEl ? progEl.innerText.trim() : '0%';
+        const date = dateEl ? dateEl.innerText.trim() : '';
+        const type_ = typeEl ? typeEl.innerText.trim() : '';
+        const meta = [progress, date, type_].filter(Boolean).join(' ∙ ');
+        return { title: (t.innerText || '').trim(), meta };
+    });
+}
+"""
+
+
 async def search_library(query: str) -> list[dict]:
     """
     Search the Speechify library for items matching `query`.
@@ -48,25 +83,7 @@ async def search_library(query: str) -> list[dict]:
         await page.wait_for_timeout(2_000)  # wait for results to filter
         log.debug("search_library: search filled+filtered (%.2fs)", time.perf_counter() - t3)
 
-        # Collect all visible library items
-        items = await page.evaluate("""
-            () => {
-                const results = [];
-                for (const btn of document.querySelectorAll('button')) {
-                    const text = btn.innerText?.trim();
-                    // Library items contain "0%" or "100%" progress + a type tag
-                    if (text && /\\d+%/.test(text) && /(web|pdf|txt|epub|mp3)/.test(text)) {
-                        const lines = text.split('\\n').map(s => s.trim()).filter(Boolean);
-                        results.push({
-                            title: lines[0] || '',
-                            meta: lines.slice(1).join(' · ')
-                        });
-                    }
-                }
-                return results;
-            }
-        """)
-
+        items = await page.evaluate(_LIBRARY_ITEMS_JS)
         return items
 
 
@@ -107,19 +124,7 @@ async def search_library_batch(queries: list[str]) -> list[int | None]:
             await search_input.fill(query)
             await page.wait_for_timeout(2_000)
 
-            items = await page.evaluate("""
-                () => {
-                    const results = [];
-                    for (const btn of document.querySelectorAll('button')) {
-                        const text = btn.innerText?.trim();
-                        if (text && /\\d+%/.test(text) && /(web|pdf|txt|epub|mp3)/.test(text)) {
-                            const lines = text.split('\\n').map(s => s.trim()).filter(Boolean);
-                            results.push({ title: lines[0] || '', meta: lines.slice(1).join(' · ') });
-                        }
-                    }
-                    return results;
-                }
-            """)
+            items = await page.evaluate(_LIBRARY_ITEMS_JS)
 
             if items:
                 pct = parse_progress_pct(items[0]["meta"])
@@ -132,6 +137,47 @@ async def search_library_batch(queries: list[str]) -> list[int | None]:
             await page.wait_for_timeout(200)
 
         return results
+
+
+# Phrase Speechify renders when an item URL is non-existent / inaccessible.
+# Confirmed live: visiting /item/<bogus-uuid> shows
+# "Oops! Something went wrong / Refresh the page or try again later /
+# Return to My Library / Need help? Contact support" (~113 chars).
+_ITEM_NOT_FOUND_PHRASE = "Oops! Something went wrong"
+
+
+async def verify_item_url(item_id: str) -> tuple[bool, str]:
+    """Confirm the Speechify item at /item/<item_id> renders real content.
+
+    Returns ``(ok, message)``. This is the reliable verification path for
+    freshly-uploaded items: Speechify's library search has indexing
+    latency (observed: 25+ minutes during the issue #45 investigation),
+    so a search by title can return zero matches for an item that
+    actually exists. Going directly to the item URL bypasses the search
+    layer entirely.
+    """
+    item_url = f"https://app.speechify.com/item/{item_id}"
+    log.debug("verify_item_url: %s", item_url)
+    async with async_new_page() as page:
+        await page.goto(item_url, wait_until="load", timeout=30_000)
+        await page.wait_for_timeout(3_000)
+        if "/item/" not in page.url:
+            return False, (
+                f"redirected away from item page to {page.url} — "
+                "likely 404 / not logged in"
+            )
+        body = await page.evaluate("() => document.body.innerText || ''")
+        if _ITEM_NOT_FOUND_PHRASE in body:
+            return False, (
+                f"page shows the {_ITEM_NOT_FOUND_PHRASE!r} overlay — "
+                "item does not exist or is inaccessible"
+            )
+        if len(body) < 200:
+            return False, (
+                f"body content is only {len(body)} chars — "
+                "item exists but appears empty / broken"
+            )
+        return True, f"body has {len(body)} chars of content"
 
 
 async def get_page_title(url: str) -> str | None:

--- a/tests/test_browser_live.py
+++ b/tests/test_browser_live.py
@@ -1,43 +1,84 @@
 """
-Live tests for speechify_add/browser.py
+Live tests for the speechify-add upload + verify pipeline.
 
-These require a real chrome-hub instance and a logged-in Speechify session.
-Run with: pytest -m live tests/test_browser_live.py
+Gated behind ``@pytest.mark.live`` and skipped by default — run with:
 
-NOTE: Per repo notes, do NOT run Playwright or browser tests in CI.
-      These are intentionally skipped in normal test runs.
+    pytest -m live tests/test_browser_live.py
+
+Requirements:
+  - chrome-hub running on localhost:9222 with a logged-in Speechify session
+  - The Speechify Firebase token captured via ``speechify-add auth setup``
+    (the API delete in cleanup uses it)
+
+Why this exists
+---------------
+Speechify's Library UI is rolling out a redesign that has already
+broken two layers of speechify-add this week:
+
+  - issue #41 — paste-text menu item replaced by a top-bar button
+  - issue #45 — library search rows changed structure, breaking verify
+
+Unit tests catch logic regressions but can't catch DOM changes. This
+roundtrip test is the canary: if any link in upload → verify → delete
+breaks, the test fails immediately on the next manual run, instead of
+silently shipping unverifiable URLs to dailybrief.
 """
+import logging
+import time
+import uuid as _uuid
+
 import pytest
 
-# ---------------------------------------------------------------------------
-# _assert_logged_in is pure logic — no live tests needed; covered in unit tests.
-# ---------------------------------------------------------------------------
+from speechify_add import api, browser, verify
 
-# ---------------------------------------------------------------------------
-# BrowserSession live smoke test
-# ---------------------------------------------------------------------------
+log = logging.getLogger(__name__)
+
+
+def _unique_marker() -> str:
+    """A short, unique-per-run string to embed in the test article so it
+    can't be confused with anything else in the user's library."""
+    return f"{int(time.time())}-{_uuid.uuid4().hex[:8]}"
+
 
 @pytest.mark.live
-class TestBrowserSessionLive:
-    def test_browser_session_requires_chrome_hub(self):
-        """
-        Documents that BrowserSession depends on chrome-hub being available.
+async def test_live_upload_verify_delete_roundtrip():
+    """End-to-end: paste text → verify the resulting item URL → delete.
 
-        External services: chrome-hub (local CDP proxy), Speechify (app.speechify.com)
-        Cost/time: ~5s, no API charges, requires logged-in Chrome profile
-        Environment: chrome-hub must be running; Speechify session must be active
+    Acts as a canary for any future Speechify UI redesign that breaks
+    one of those steps. The test article has a unique marker so a
+    failed cleanup leaves an obvious breadcrumb instead of polluting
+    the user's library silently.
 
-        This is a placeholder — actual session tests require a live browser
-        and are not safe to automate without a sandboxed test account.
-        """
-        # The real test would be:
-        #   async with BrowserSession() as session:
-        #       assert session._page is not None
-        #
-        # Skipped here because:
-        # 1. Requires chrome-hub to be running (local service)
-        # 2. Requires a logged-in Speechify session
-        # 3. Per repo notes: do not run Playwright/browser tests
-        pytest.skip(
-            "Requires chrome-hub + live Speechify session — run manually only"
+    Cleanup uses ``api.delete_item`` (Firebase archive endpoint), which
+    is independent of the browser-automation flow being tested.
+    """
+    marker = _unique_marker()
+    title = f"speechify-add live roundtrip {marker}"
+    text = (
+        f"Automated speechify-add roundtrip test — marker {marker}. "
+        "If you see this in your library after a test run, the live "
+        "test failed during cleanup. Safe to delete."
+    )
+
+    log.info("upload: %s", title)
+    item_url = await browser.add_text(text, title=title)
+    item_id = browser._extract_item_id(item_url)
+    assert item_id, f"upload returned a URL with no item UUID: {item_url}"
+
+    try:
+        ok, info = await verify.verify_item_url(item_id)
+        assert ok, (
+            f"verify_item_url returned False for {item_id} "
+            f"(test article we just uploaded): {info}"
         )
+    finally:
+        # Always clean up — even if verify failed, the item is real and
+        # would otherwise pollute the library.
+        try:
+            await api.delete_item(item_id)
+        except Exception as cleanup_err:
+            pytest.fail(
+                f"cleanup failed for {item_id}: {cleanup_err}. "
+                "The test article is still in the library; delete it "
+                f"manually with: speechify-add delete {item_id} --mode api"
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,8 +334,10 @@ class TestDoVerify:
 
     def test_url_with_empty_title_falls_back_to_url_path(self, capsys):
         with patch("speechify_add.verify.get_page_title", AsyncMock(return_value=None)):
+            # Issue #45: result must title-match the search term to verify; the
+            # fixture title contains the URL-path words so the strict match passes.
             with patch("speechify_add.verify.search_library", AsyncMock(return_value=[
-                {"title": "Some Result", "meta": ""}
+                {"title": "My Article About Science", "meta": ""}
             ])) as mock_search:
                 run(_do_verify("https://example.com/my-article-about-science"))
 
@@ -347,6 +349,40 @@ class TestDoVerify:
         with patch("speechify_add.verify.search_library", AsyncMock(return_value=[])):
             with pytest.raises(SystemExit):
                 run(_do_verify("nothing found here"))
+
+    def test_fuzzy_results_without_title_match_raises_systemexit(self):
+        """Issue #45: Speechify search is fuzzy, so non-empty results don't
+        prove the specific item we asked about exists. Verify must require
+        a title-substring match before exiting 0; otherwise dailybrief's
+        verify-after-upload step (which calls this CLI) treats every upload
+        as verified just because *some* article matched the query."""
+        fuzzy_misses = [
+            {"title": "Your website is not for you", "meta": ""},
+            {"title": "AI agent's response time", "meta": ""},
+        ]
+        with patch("speechify_add.verify.search_library", AsyncMock(return_value=fuzzy_misses)):
+            with pytest.raises(SystemExit):
+                run(_do_verify("LLMs corrupt your documents"))
+
+    def test_strict_match_passes_when_title_contains_query(self):
+        """If at least one returned title contains the query (case-insensitive),
+        verify exits 0."""
+        with patch("speechify_add.verify.search_library", AsyncMock(return_value=[
+            {"title": "Some Other Article", "meta": ""},
+            {"title": "LLMs Corrupt Your Documents When You Delegate", "meta": "0% ∙ May 9 ∙ txt"},
+        ])):
+            # Must not raise SystemExit
+            run(_do_verify("LLMs corrupt your documents"))
+
+    def test_strict_match_passes_when_query_contains_title(self):
+        """Reverse direction: if the result title is itself a substring of the
+        query (e.g. user passes a long title, library has a shorter form),
+        treat it as a match."""
+        with patch("speechify_add.verify.search_library", AsyncMock(return_value=[
+            {"title": "Bun ported to Rust", "meta": ""},
+        ])):
+            # User searches for the longer phrasing; library has shorter title.
+            run(_do_verify("Bun ported to Rust in 6 days"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -384,6 +384,46 @@ class TestDoVerify:
             # User searches for the longer phrasing; library has shorter title.
             run(_do_verify("Bun ported to Rust in 6 days"))
 
+    def test_uuid_input_takes_url_based_path(self):
+        """Issue #45: a bare UUID or item URL routes to verify_item_url and
+        skips the (lossy) library-search path entirely."""
+        uuid = "cff1772b-7603-4d46-966c-97b4b4566443"
+        with patch(
+            "speechify_add.verify.verify_item_url",
+            AsyncMock(return_value=(True, "body has 1234 chars of content")),
+        ) as vmocked, patch(
+            "speechify_add.verify.search_library",
+            AsyncMock(return_value=[]),
+        ) as smocked:
+            run(_do_verify(uuid))
+        vmocked.assert_awaited_once_with(uuid)
+        smocked.assert_not_awaited()
+
+    def test_full_item_url_takes_url_based_path(self):
+        """Same routing for a complete /item/<uuid> URL."""
+        uuid = "cff1772b-7603-4d46-966c-97b4b4566443"
+        url = f"https://app.speechify.com/item/{uuid}"
+        with patch(
+            "speechify_add.verify.verify_item_url",
+            AsyncMock(return_value=(True, "body has 1234 chars of content")),
+        ) as vmocked, patch(
+            "speechify_add.verify.search_library",
+            AsyncMock(return_value=[]),
+        ) as smocked:
+            run(_do_verify(url))
+        vmocked.assert_awaited_once_with(uuid)
+        smocked.assert_not_awaited()
+
+    def test_url_based_verify_failure_exits_nonzero(self):
+        """When verify_item_url returns (False, msg), CLI exits 1."""
+        uuid = "00000000-0000-0000-0000-000000000000"
+        with patch(
+            "speechify_add.verify.verify_item_url",
+            AsyncMock(return_value=(False, "page shows the 'Oops! ...' overlay")),
+        ):
+            with pytest.raises(SystemExit):
+                run(_do_verify(uuid))
+
 
 # ---------------------------------------------------------------------------
 # Integration tests


### PR DESCRIPTION
## Summary

Closes #45. End-to-end run of dailybrief revealed `speechify-add verify` returned 0 results for every freshly-uploaded item. Two compounding causes — both fixed here.

**1. Library DOM redesign.** Old result-extraction regex (`<button>` containing inline "73% · web") finds nothing in the new UI; items now render as `<div role="button">` with structural testids. Replaced the brittle regex with a structural query keyed on `library-item-title` / `library-item-progress` / `library-item-date` / `library-item-type`. 0%-progress items omit the progress div entirely; we synthesize "0%" so `parse_progress_pct` keeps working.

**2. Search indexing latency.** Even with the correct DOM, freshly uploaded items don't surface in Speechify's library search for ~minutes. Verified live: searching the EXACT title of a 25-min-old item returned 19 fuzzy matches with the actual item nowhere in the rendered top 15. Search-based verify is fundamentally unreliable for "did the upload I just did land?". Added `verify.verify_item_url(item_id)` that goes straight to `/item/<uuid>` and checks the page renders real content (not the "Oops! Something went wrong" overlay Speechify shows for missing items, and not a near-empty body). The CLI now detects when input is a Speechify item URL or bare UUID and routes to URL-based verification.

**Belt-and-braces tightening:** the search path no longer treats a non-empty result list as success. We require at least one returned title to substring-match the query (case-insensitive, either direction). Otherwise dailybrief's verify-after-upload would falsely "verify" any upload just because Speechify's fuzzy search returned ANY related article.

**Live roundtrip canary:** `tests/test_browser_live.py::test_live_upload_verify_delete_roundtrip` now does a real upload → verify-by-URL → API delete against current Speechify, with a uniquely-marked test article. If a future Speechify UI redesign breaks any link, this trips on the next manual run instead of silently shipping unverifiable URLs.

**While we're here:** registered the `live` pytest marker and turned on `asyncio_mode = "auto"` in `pyproject.toml`. The pre-existing `async def` live tests in `test_verify_live.py` were silently broken before (collected, then errored with "async def not supported"); they pass now.

## Test plan

- [x] `pytest` (default, skips live) — 263 passed, 15 deselected (live).
- [x] `pytest -m live` — 4 passed (placeholder browser test replaced; existing httpx tests now actually run; new roundtrip canary passes in ~13s).
- [x] Live roundtrip verified manually: real upload → real verify-by-URL → real API delete; cleaned up.
- [x] Live URL-verify CLI tested: known-good item → exit 0; bogus UUID → exit 1 with `'Oops! Something went wrong' overlay` message.
- [ ] dailybrief follow-up: switch its #53 verify-after-upload step from `speechify-add verify "<title>"` to `speechify-add verify "<url>"` to use the reliable mode. Will file separately.

Generated with [Claude Code](https://claude.com/claude-code)