### PR TITLE
fix: poll verify_item_url for fresh-upload race (#47)

### DIFF
--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -146,7 +146,22 @@ async def search_library_batch(queries: list[str]) -> list[int | None]:
 _ITEM_NOT_FOUND_PHRASE = "Oops! Something went wrong"
 
 
-async def verify_item_url(item_id: str) -> tuple[bool, str]:
+# Minimum body length we treat as "real content" on an item page. The
+# "Oops! Something went wrong" stub is ~113 chars; legitimate items are
+# 1000+ chars (title + summary + player UI text).
+_PLAYABLE_MIN_BODY_CHARS = 200
+
+# How long verify_item_url polls before giving up. Issue #47: the page
+# can briefly render the "Oops!" overlay or a near-empty body for ~20s
+# right after upload while Speechify finalizes the item server-side.
+_VERIFY_ITEM_MAX_WAIT_SEC = 30.0
+# Interval between polls within that window.
+_VERIFY_ITEM_POLL_INTERVAL_SEC = 2.0
+
+
+async def verify_item_url(
+    item_id: str, *, max_wait: float = _VERIFY_ITEM_MAX_WAIT_SEC,
+) -> tuple[bool, str]:
     """Confirm the Speechify item at /item/<item_id> renders real content.
 
     Returns ``(ok, message)``. This is the reliable verification path for
@@ -155,29 +170,50 @@ async def verify_item_url(item_id: str) -> tuple[bool, str]:
     so a search by title can return zero matches for an item that
     actually exists. Going directly to the item URL bypasses the search
     layer entirely.
+
+    Issue #47: a fixed-wait probe races the post-upload render — fresh
+    items can briefly show the "Oops!" overlay or a near-empty body
+    before the page settles, especially under chrome-hub contention
+    when verify_uploads runs in parallel. We poll instead of waiting a
+    single fixed interval: healthy items pass on the first probe (~2s);
+    fresh ones get up to ``max_wait`` to settle; truly missing items
+    fail reliably because the overlay persists across every poll.
     """
     item_url = f"https://app.speechify.com/item/{item_id}"
-    log.debug("verify_item_url: %s", item_url)
+    log.debug("verify_item_url: %s (max_wait=%.0fs)", item_url, max_wait)
     async with async_new_page() as page:
         await page.goto(item_url, wait_until="load", timeout=30_000)
-        await page.wait_for_timeout(3_000)
-        if "/item/" not in page.url:
-            return False, (
-                f"redirected away from item page to {page.url} — "
-                "likely 404 / not logged in"
+        deadline = time.monotonic() + max_wait
+        last_reason = "no checks completed before deadline"
+        polls = 0
+        while time.monotonic() < deadline:
+            await page.wait_for_timeout(int(_VERIFY_ITEM_POLL_INTERVAL_SEC * 1000))
+            polls += 1
+            if "/item/" not in page.url:
+                return False, (
+                    f"redirected away from item page to {page.url} — "
+                    "likely 404 / not logged in"
+                )
+            body = await page.evaluate("() => document.body.innerText || ''")
+            if _ITEM_NOT_FOUND_PHRASE in body:
+                last_reason = (
+                    f"showing {_ITEM_NOT_FOUND_PHRASE!r} overlay "
+                    f"(poll {polls})"
+                )
+                continue
+            if len(body) < _PLAYABLE_MIN_BODY_CHARS:
+                last_reason = (
+                    f"body still only {len(body)} chars (poll {polls})"
+                )
+                continue
+            return True, (
+                f"body has {len(body)} chars of content "
+                f"(settled after {polls} poll(s))"
             )
-        body = await page.evaluate("() => document.body.innerText || ''")
-        if _ITEM_NOT_FOUND_PHRASE in body:
-            return False, (
-                f"page shows the {_ITEM_NOT_FOUND_PHRASE!r} overlay — "
-                "item does not exist or is inaccessible"
-            )
-        if len(body) < 200:
-            return False, (
-                f"body content is only {len(body)} chars — "
-                "item exists but appears empty / broken"
-            )
-        return True, f"body has {len(body)} chars of content"
+        return False, (
+            f"item never became playable within {max_wait:.0f}s "
+            f"({polls} polls; last: {last_reason})"
+        )
 
 
 async def get_page_title(url: str) -> str | None:

--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -208,7 +208,7 @@ async def verify_item_url(
                 continue
             return True, (
                 f"body has {len(body)} chars of content "
-                f"(settled after {polls} poll(s))"
+                f"(settled after {polls} poll{'s' if polls != 1 else ''})"
             )
         return False, (
             f"item never became playable within {max_wait:.0f}s "

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -11,7 +11,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from speechify_add.verify import get_page_title, parse_progress_pct, search_library_batch
+from speechify_add.verify import (
+    get_page_title,
+    parse_progress_pct,
+    search_library_batch,
+    verify_item_url,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -218,3 +223,121 @@ class TestSearchLibraryBatchIntegration:
             results = await search_library_batch(["unread"])
         assert results == [0]
         assert results[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# verify_item_url polling (issue #47)
+# ---------------------------------------------------------------------------
+
+def _mock_item_page_cm(*, url: str, body_sequence: list[str]):
+    """Make an async-context-manager that yields a page whose `evaluate(...)`
+    returns successive bodies from `body_sequence`. Lets us simulate "the page
+    starts with the Oops! overlay then settles to real content" scenarios.
+    """
+    page = MagicMock()
+    page.url = url
+    page.goto = AsyncMock()
+    page.wait_for_timeout = AsyncMock()
+
+    # Each call to page.evaluate(...) returns the next body in the sequence.
+    # When the sequence is exhausted, repeat the last body forever (so a
+    # caller polling past the deadline sees the same final state).
+    iterator = iter(body_sequence)
+    last = body_sequence[-1] if body_sequence else ""
+
+    async def _eval(_js):
+        nonlocal last
+        try:
+            last = next(iterator)
+        except StopIteration:
+            pass
+        return last
+
+    page.evaluate = _eval
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=page)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm, page
+
+
+class TestVerifyItemUrl:
+    UUID = "cff1772b-7603-4d46-966c-97b4b4566443"
+    GOOD_BODY = (
+        "Real Article Title\nShare\n\nA full body of meaningful content "
+        "going on for hundreds of characters because this is what a real "
+        "Speechify item page looks like with title, summary, and player "
+        "controls all rendered." * 2
+    )
+    OOPS_BODY = (
+        "Oops! Something went wrong\n\nRefresh the page or try again later.\n"
+        "\nReturn to My Library\nNeed help? Contact support"
+    )
+
+    @pytest.mark.asyncio
+    async def test_passes_immediately_for_settled_item(self):
+        """A healthy item returns True on the first poll."""
+        cm, _ = _mock_item_page_cm(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.GOOD_BODY],
+        )
+        with patch("speechify_add.verify.async_new_page", return_value=cm):
+            ok, info = await verify_item_url(self.UUID, max_wait=10)
+        assert ok is True
+        assert "1 poll" in info  # settled on first poll
+
+    @pytest.mark.asyncio
+    async def test_settles_after_initial_oops(self):
+        """A fresh upload that briefly shows the Oops! overlay still passes
+        once the page settles within the budget (issue #47 core scenario)."""
+        cm, _ = _mock_item_page_cm(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[
+                self.OOPS_BODY,           # poll 1: still rendering
+                self.OOPS_BODY,           # poll 2: still rendering
+                self.GOOD_BODY,           # poll 3: done
+            ],
+        )
+        with patch("speechify_add.verify.async_new_page", return_value=cm):
+            ok, info = await verify_item_url(self.UUID, max_wait=10)
+        assert ok is True
+        assert "3 poll" in info
+
+    @pytest.mark.asyncio
+    async def test_settles_after_short_body(self):
+        """Same idea but the partial state is a near-empty body, not the
+        Oops! overlay."""
+        cm, _ = _mock_item_page_cm(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=["…", "loading…", self.GOOD_BODY],
+        )
+        with patch("speechify_add.verify.async_new_page", return_value=cm):
+            ok, info = await verify_item_url(self.UUID, max_wait=10)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_overlay_persists(self):
+        """A truly missing item shows the Oops! overlay across every poll —
+        we should fail with a clear message after the deadline."""
+        cm, _ = _mock_item_page_cm(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.OOPS_BODY],  # repeats forever
+        )
+        with patch("speechify_add.verify.async_new_page", return_value=cm):
+            ok, info = await verify_item_url(self.UUID, max_wait=4)
+        assert ok is False
+        assert "Oops" in info
+        assert "never became playable" in info
+
+    @pytest.mark.asyncio
+    async def test_fails_when_redirected_away(self):
+        """If the page redirects away from /item/<uuid> (e.g. to /login),
+        bail immediately."""
+        cm, _ = _mock_item_page_cm(
+            url="https://app.speechify.com/login",
+            body_sequence=["irrelevant"],
+        )
+        with patch("speechify_add.verify.async_new_page", return_value=cm):
+            ok, info = await verify_item_url(self.UUID, max_wait=10)
+        assert ok is False
+        assert "redirected" in info.lower()


### PR DESCRIPTION
## Summary

Closes #47. Today's manual dailybrief run dropped 5/15 listen URLs from the digest because `verify_item_url`'s fixed 3s wait raced Speechify's post-upload render. Manual re-probe of the same URLs ~2 min later passed cleanly with 2200–2700 chars of real content — the items were fine, the verify just bailed too early. The race is exacerbated by chrome-hub contention when dailybrief's `verify_uploads` runs 4 verifies in parallel.

Switch the single 3s wait to a polling loop with a 30s budget:

- Healthy / settled items pass on the first probe (~2s) — no slowdown.
- Fresh uploads get up to `max_wait` for the page to settle. The "Oops!" overlay or a near-empty body during initial render no longer fails the verify; we keep polling.
- Truly missing items still fail reliably because the overlay persists across every poll. The error message names which signal last failed and how many polls ran, making future debugging easier than "expected length, got 113".

`verify_item_url` gains a `max_wait` kwarg (default 30s); poll interval is 2s. Both are module-level constants so a future caller can tune without monkey-patching.

## Test plan

- [x] `pytest -m "not live"` — 271 passed (was 266; +5 new `TestVerifyItemUrl` cases: settled-on-first-poll happy path, settles-after-N-polls (the issue scenario), partial-body, persistent overlay → fail, redirect → fail).
- [x] `pytest -m live` — 4 passed including the upload→verify→delete roundtrip canary in 12.38s; verify settled in one poll (~2s) for a freshly-uploaded item.
- [ ] Manual re-run of dailybrief end-to-end: confirm `Speechify: N/N uploaded` (today's was 10/15 with 5 false-fails; expect 15/15 now).

Generated with [Claude Code](https://claude.com/claude-code)