### PR TITLE
fix: extend verify_item_url polling window from 30s to 60s

### DIFF
--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -154,7 +154,9 @@ _PLAYABLE_MIN_BODY_CHARS = 200
 # How long verify_item_url polls before giving up. Issue #47: the page
 # can briefly render the "Oops!" overlay or a near-empty body for ~20s
 # right after upload while Speechify finalizes the item server-side.
-_VERIFY_ITEM_MAX_WAIT_SEC = 30.0
+# 60s observed necessary for slow-rendering articles (185-char body at
+# 30s that would settle to full content given more time).
+_VERIFY_ITEM_MAX_WAIT_SEC = 60.0
 # Interval between polls within that window.
 _VERIFY_ITEM_POLL_INTERVAL_SEC = 2.0
 


### PR DESCRIPTION
## Summary
- Increases `_VERIFY_ITEM_MAX_WAIT_SEC` from 30 to 60 seconds in `verify_item_url`
- Observed in production: slow-rendering articles show only 185 chars at the 30s mark but settle to full content given more time
- The 30s window was insufficient for some articles, causing valid Speechify items to be dropped from the daily brief (19/20 instead of 20/20)

## Test plan
- [x] Unit test suite: 244 passed, 0 failed
- [x] All existing `verify_item_url` tests use explicit `max_wait=` params — unaffected by constant change
- [ ] Live: next full dailybrief run will confirm 20/20 uploads verified
- Skipped live test suite (constant bump; existing tests exercise all code paths with explicit max_wait params)

Generated with [Claude Code](https://claude.com/claude-code)