### PR TITLE
fix: lower _PLAYABLE_MIN_BODY_CHARS from 200 to 150

### DIFF
--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -147,9 +147,10 @@ _ITEM_NOT_FOUND_PHRASE = "Oops! Something went wrong"
 
 
 # Minimum body length we treat as "real content" on an item page. The
-# "Oops! Something went wrong" stub is ~113 chars; legitimate items are
-# 1000+ chars (title + summary + player UI text).
-_PLAYABLE_MIN_BODY_CHARS = 200
+# "Oops! Something went wrong" stub is ~113 chars. Paywalled articles
+# can produce short extractions (~185 chars rendered on the item page),
+# so 150 gives a safe margin above the error stub while accepting them.
+_PLAYABLE_MIN_BODY_CHARS = 150
 
 # How long verify_item_url polls before giving up. Issue #47: the page
 # can briefly render the "Oops!" overlay or a near-empty body for ~20s


### PR DESCRIPTION
## Summary
- Lowers `_PLAYABLE_MIN_BODY_CHARS` from 200 to 150 in `verify_item_url`
- Paywalled articles with short trafilatura extractions consistently render ~185 chars on the Speechify item page — above the 113-char "Oops!" error stub but below the old 200-char threshold
- The explicit `_ITEM_NOT_FOUND_PHRASE` check already guards the true error case, so 150 is a safe floor that accepts short-content items while still rejecting the known error state
- Observed: "I Work in Hollywood. Everyone Who Used to Make TV Is Now Training AI" fails consistently at 185 chars; this fix makes it pass

## Test plan
- [x] Unit test suite: 244 passed, 0 failed
- [x] GOOD_BODY in tests is well above 150 chars — all existing verify tests unaffected
- [ ] Live: next full dailybrief run will confirm 20/20 uploads verified
- Skipped live test suite (constant change; all code paths exercised by unit tests)

Generated with [Claude Code](https://claude.com/claude-code)