### PR TITLE
fix: route add_text through file-upload to persist content blobs (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ All three are sync wrappers around the underlying async browser flows — they m
 
 ### Issue #51 — text routes through file-upload
 
-`upload_text` (and the underlying `browser.add_text`) writes the text to a temp `.txt` file and uploads it via Speechify's file-upload flow. The SPA's *paste-text* flow doesn't persist content blobs to Firebase Storage — items end up cached only in the upload session's local IndexedDB and render `"Oops!"` for every other browser. The file-upload flow POSTs to Firebase Storage explicitly, producing items any session can read. Trade-off: text uploads now take ~50–60s (vs ~10s) because we wait for fresh-context verification to confirm the content blob is server-side fetchable before returning. Failures raise instead of returning broken URLs.
+`upload_text` (and the underlying `browser.add_text`) writes the text to a temp `.txt` file and uploads it via Speechify's file-upload flow. The SPA's *paste-text* flow doesn't persist content blobs to Firebase Storage — items end up cached only in the upload session's local IndexedDB and render `"Oops!"` for every other browser. The file-upload flow POSTs to Firebase Storage explicitly, producing items any session can read.
+
+Notes on behavior:
+- **Latency**: text uploads now take ~50–60s (vs ~10s) because we wait for fresh-context verification to confirm the content blob is server-side fetchable before returning.
+- **Failure mode**: if the content blob doesn't persist within the 90s budget, the call raises instead of returning a broken URL.
+- **Title rendering**: Speechify uses the uploaded file's basename as the item title (the file-upload flow has no title field). The `title` arg is sanitized into a filesystem-safe name — e.g. `upload_text(text, title="My Article")` produces an item titled `My-Article` in the library.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ All three are sync wrappers around the underlying async browser flows — they m
 
 `upload_url` returns an empty string if Speechify accepted the URL but didn't redirect to the item page within ~15 seconds (the URL was still queued — we just couldn't observe its id).
 
+### Issue #51 — text routes through file-upload
+
+`upload_text` (and the underlying `browser.add_text`) writes the text to a temp `.txt` file and uploads it via Speechify's file-upload flow. The SPA's *paste-text* flow doesn't persist content blobs to Firebase Storage — items end up cached only in the upload session's local IndexedDB and render `"Oops!"` for every other browser. The file-upload flow POSTs to Firebase Storage explicitly, producing items any session can read. Trade-off: text uploads now take ~50–60s (vs ~10s) because we wait for fresh-context verification to confirm the content blob is server-side fetchable before returning. Failures raise instead of returning broken URLs.
+
 ---
 
 ## How It Works

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -12,7 +12,9 @@ batch uploads don't re-navigate between items.
 
 import asyncio
 import logging
+import os
 import re
+import tempfile
 import time
 from pathlib import Path
 
@@ -169,14 +171,20 @@ class BrowserSession:
         await self._navigate_to_library()
 
     async def add_text(self, text: str, title: str = "") -> str:
-        """Add raw text via the Paste Text flow, reusing the open browser.
+        """Add raw text by routing through the file-upload flow.
 
-        On any failure mid-flow, attempts to delete a partial item if one was
-        already created (URL is on /item/<uuid>) before re-raising — this
-        keeps the user's library clean and stops the caller's retry path
-        from picking up an orphaned half-state item (issue #39).
+        Issue #51: Speechify's paste-text flow only writes the content to
+        the SPA's local IndexedDB; the background sync to Firebase Storage
+        is broken, so paste-text items show "Oops!" for every browser
+        except the upload session. Routing text through a temp .txt file
+        and the explicit file-upload flow (which POSTs to Firebase Storage
+        synchronously) produces items that any browser can read.
+
+        Side effect: each call opens its own page via ``add_file`` — the
+        session's open page is no longer reused for text adds. The
+        performance cost is small relative to Speechify's processing time.
         """
-        doc_url = await _add_text_with_cleanup(self._page, text, title, self.debug)
+        doc_url = await _add_text_via_file(text, title, self.debug)
         await self._navigate_to_library()
         return doc_url
 
@@ -187,25 +195,68 @@ class BrowserSession:
 
 async def add_text(text: str, title: str = "", debug: bool = False) -> str:
     """
-    Add raw text to Speechify via the "Paste Text" UI flow.
+    Add raw text to Speechify by routing through the file-upload flow.
+
     Returns the Speechify document URL (e.g. https://app.speechify.com/item/<uuid>).
 
-    On any failure mid-flow, attempts to delete a partial item if one
-    was already created (URL is on /item/<uuid>) before re-raising
-    (issue #39).
+    Issue #51: Speechify's paste-text UI flow does not persist the
+    content blob to Firebase Storage — items end up in the upload
+    session's local IndexedDB only, rendering "Oops!" for every other
+    browser. The file-upload flow POSTs to Firebase Storage explicitly,
+    so items produced by it are readable by any authenticated session.
+    This function writes ``text`` to a temporary .txt file, uploads via
+    ``add_file``, then deletes the temp file.
     """
-    async with async_new_page() as page:
-        await _init_speechify_page(page)
+    return await _add_text_via_file(text, title, debug)
 
-        if debug:
-            await _save_screenshot(page, "text-01-page-loaded")
 
-        doc_url = await _add_text_with_cleanup(page, text, title, debug)
+_SAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+_MAX_FILENAME_LEN = 80
 
-        if debug:
-            await _save_screenshot(page, "text-04-done")
 
-        return doc_url
+def _filename_from_title(title: str) -> str:
+    """Sanitize ``title`` into a filesystem-safe basename.
+
+    Speechify uses the uploaded filename as the item's title when no
+    other metadata is available, so preserving the human-readable title
+    here matters for the user-visible library entry.
+    """
+    cleaned = _SAFE_FILENAME_CHARS.sub("-", title.strip())
+    cleaned = cleaned.strip("-._") or "speechify-add"
+    if len(cleaned) > _MAX_FILENAME_LEN:
+        cleaned = cleaned[:_MAX_FILENAME_LEN].rstrip("-._") or "speechify-add"
+    return cleaned
+
+
+async def _add_text_via_file(text: str, title: str, debug: bool) -> str:
+    """Write ``text`` to a temp .txt file and upload via ``add_file``.
+
+    Issue #51 workaround: the paste-text UI flow doesn't persist content
+    blobs server-side. File uploads do. See ``add_text`` docstring.
+    """
+    safe_name = _filename_from_title(title) if title else "speechify-add-text"
+    # Use ``delete=False`` so we control unlinking; the file must exist
+    # for the entire ``add_file`` duration (Firebase upload reads it).
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f"{safe_name}__", suffix=".txt"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        tmp_path = Path(tmp_path_str)
+        log.debug(
+            "_add_text_via_file: wrote %d chars to %s",
+            len(text), tmp_path,
+        )
+        return await add_file(tmp_path, title=title, debug=debug)
+    finally:
+        try:
+            os.unlink(tmp_path_str)
+        except OSError as e:
+            log.warning(
+                "_add_text_via_file: failed to unlink %s: %s",
+                tmp_path_str, e,
+            )
 
 
 async def add_url(url: str, debug: bool = False) -> str:
@@ -300,6 +351,21 @@ async def add_file(path: Path, title: str = "", debug: bool = False) -> str:
         doc_url = await _wait_for_item_redirect(page, timeout_seconds=180)
         log.debug("add_file: redirect observed in %.2fs", time.perf_counter() - t5)
         log.debug("add_file: TOTAL %.2fs -> %s", time.perf_counter() - t0, doc_url)
+
+        # Issue #51: even on the file-upload path, confirm the item is
+        # actually fetchable from a fresh session (no shared IndexedDB)
+        # before returning. Items that exist only in the upload session's
+        # local cache would otherwise ship as broken URLs to callers.
+        item_id = _extract_item_id(doc_url)
+        if item_id:
+            await _verify_or_cleanup_fresh_context(
+                doc_url, item_id, page, debug=debug,
+            )
+        else:
+            log.warning(
+                "Could not extract item UUID from %r; skipping fresh-context verify",
+                doc_url,
+            )
         return doc_url
 
 
@@ -548,18 +614,94 @@ async def _find_first_visible(page, selectors, step, timeout=5_000):
 # logic isn't duplicated in two places (issue #39).
 # ---------------------------------------------------------------------------
 
+# Issue #51: post-upload, give the SPA up to this long to finish any
+# background work that persists the content blob to Firebase Storage,
+# then confirm the item is fetchable from a session that didn't do the
+# upload. If verify still fails after this budget, the item exists
+# only in the upload session's IndexedDB and would render "Oops!" for
+# every other browser — fail closed instead of returning a broken URL.
+POST_UPLOAD_VERIFY_BUDGET_SEC = 90.0
+POST_UPLOAD_VERIFY_INTERVAL_SEC = 5.0
+
+
 async def _add_text_with_cleanup(
     page, text: str, title: str, debug: bool
 ) -> str:
     """Run ``_do_add_text``, deleting any partial item before re-raising
-    on failure (issue #39). Shared by ``BrowserSession.add_text`` and the
-    standalone ``add_text``.
+    on failure (issue #39).
+
+    .. deprecated:: issue #51
+        The paste-text flow does not persist content blobs to Firebase
+        Storage; resulting items show "Oops!" for every browser except
+        the upload session. ``add_text`` now routes through ``add_file``
+        instead. This helper is kept for reference / fallback callers,
+        but is not on the live upload path.
     """
     try:
         return await _do_add_text(page, text, title=title, debug=debug)
     except Exception:
         await _maybe_delete_partial_item(page, debug=debug)
         raise
+
+
+async def _verify_or_cleanup_fresh_context(
+    item_url: str, item_id: str, page, *, debug: bool,
+) -> None:
+    """Poll a fresh-context verify until the item is fetchable or budget runs out.
+
+    The SPA may finish persisting the content blob asynchronously after
+    redirecting to /item/<uuid>. Retry on a 5s cadence within
+    ``POST_UPLOAD_VERIFY_BUDGET_SEC`` to give it time. If still failing
+    at the deadline, archive the item via the page UI (best-effort) and
+    raise — callers can decide whether to retry the whole upload.
+    """
+    # Imported lazily to avoid a circular import at module load time.
+    from speechify_add.verify import verify_item_url_fresh_context
+
+    deadline = time.monotonic() + POST_UPLOAD_VERIFY_BUDGET_SEC
+    attempt = 0
+    last_reason = "no verify attempts completed"
+    while time.monotonic() < deadline:
+        attempt += 1
+        remaining = deadline - time.monotonic()
+        # Cap each attempt at remaining-budget so we don't overshoot.
+        attempt_wait = min(30.0, max(5.0, remaining))
+        ok, reason = await verify_item_url_fresh_context(
+            item_id, max_wait=attempt_wait,
+        )
+        if ok:
+            log.info(
+                "Fresh-context verify passed for %s on attempt %d (%s)",
+                item_id, attempt, reason,
+            )
+            return
+        last_reason = reason
+        log.warning(
+            "Fresh-context verify attempt %d for %s failed: %s",
+            attempt, item_id, reason,
+        )
+        if time.monotonic() >= deadline:
+            break
+        await asyncio.sleep(POST_UPLOAD_VERIFY_INTERVAL_SEC)
+
+    # Budget exhausted — item never persisted server-side. Try to clean up.
+    log.error(
+        "Item %s never became fetchable from a fresh session within %.0fs "
+        "(last: %s) — content blob did not persist (issue #51). Cleaning up.",
+        item_id, POST_UPLOAD_VERIFY_BUDGET_SEC, last_reason,
+    )
+    try:
+        await _perform_delete(page, item_id, debug=debug)
+    except Exception as cleanup_err:
+        log.warning(
+            "Cleanup of unpersisted item %s failed: %s", item_id, cleanup_err,
+        )
+    raise RuntimeError(
+        f"Speechify item {item_id} uploaded but content blob never "
+        f"persisted to Firebase Storage within {POST_UPLOAD_VERIFY_BUDGET_SEC:.0f}s "
+        f"(issue #51). URL would render 'Oops!' for any other browser. "
+        f"Last verify reason: {last_reason}"
+    )
 
 
 async def _open_paste_text_modal(page) -> str:

--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -11,8 +11,10 @@ import re
 import time
 
 import httpx
+from playwright.async_api import async_playwright
 
 from chrome_hub import async_new_page
+from chrome_hub.browser import CDP_URL
 
 log = logging.getLogger(__name__)
 
@@ -217,6 +219,115 @@ async def verify_item_url(
             f"item never became playable within {max_wait:.0f}s "
             f"({polls} polls; last: {last_reason})"
         )
+
+
+# Issue #51: verify_item_url runs inside chrome-hub's default browser
+# context, which also holds the IndexedDB caches written during upload.
+# Broken items (Firestore record exists, Firebase Storage content blob
+# missing) still render from those caches — so the in-session probe is
+# blind to the bug class that produces unreadable URLs for other browsers.
+# verify_item_url_fresh_context opens a clean BrowserContext on the same
+# Chrome instance (no shared cookies / localStorage / IndexedDB), then
+# transplants only the Speechify auth cookies so we can navigate as the
+# logged-in user. This reproduces what a fresh tab on the user's phone
+# sees: if the content blob isn't fetchable, the page renders the
+# "Oops! Something went wrong" overlay and we fail closed.
+_FRESH_AUTH_COOKIE_NAMES = {"session", "axwrt", "cf_clearance"}
+_FRESH_CTX_MAX_WAIT_SEC = 30.0
+_FRESH_CTX_POLL_INTERVAL_SEC = 2.0
+
+
+async def verify_item_url_fresh_context(
+    item_id: str, *, max_wait: float = _FRESH_CTX_MAX_WAIT_SEC,
+) -> tuple[bool, str]:
+    """Confirm /item/<item_id> renders for a session that did NOT do the upload.
+
+    Connects to the same chrome-hub Chrome via CDP, but creates a fresh
+    BrowserContext with no shared storage. Copies the Speechify auth
+    cookies from chrome-hub's default context so the new context is
+    logged in as the same user, then polls the item page the same way
+    verify_item_url does.
+
+    A False return here proves the item is unfetchable by ordinary
+    user sessions — even though verify_item_url (which sees the upload
+    session's IndexedDB cache) may still return True. See issue #51.
+
+    Returns ``(ok, message)``. The caller is responsible for retrying
+    on transient False if it's appropriate (post-upload settle).
+    """
+    item_url = f"https://app.speechify.com/item/{item_id}"
+    log.debug(
+        "verify_item_url_fresh_context: %s (max_wait=%.0fs)",
+        item_url, max_wait,
+    )
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.connect_over_cdp(CDP_URL)
+
+        # Pull auth cookies off whichever default context chrome-hub set up.
+        # contexts[0] is the shared session that owns the upload-time state.
+        auth_cookies = []
+        if browser.contexts:
+            default_ctx = browser.contexts[0]
+            all_cookies = await default_ctx.cookies(
+                ["https://app.speechify.com/", "https://speechify.com/"]
+            )
+            auth_cookies = [
+                c for c in all_cookies if c.get("name") in _FRESH_AUTH_COOKIE_NAMES
+            ]
+        if not auth_cookies:
+            return False, (
+                "no Speechify auth cookies available in chrome-hub default "
+                "context — fresh-context verify cannot authenticate"
+            )
+
+        fresh_ctx = await browser.new_context()
+        try:
+            await fresh_ctx.add_cookies(auth_cookies)
+            page = await fresh_ctx.new_page()
+            try:
+                await page.goto(item_url, wait_until="load", timeout=30_000)
+                deadline = time.monotonic() + max_wait
+                last_reason = "no checks completed before deadline"
+                polls = 0
+                while time.monotonic() < deadline:
+                    await page.wait_for_timeout(
+                        int(_FRESH_CTX_POLL_INTERVAL_SEC * 1000)
+                    )
+                    polls += 1
+                    if "/item/" not in page.url:
+                        return False, (
+                            f"fresh context redirected from item page to "
+                            f"{page.url} — auth cookie was rejected or item "
+                            "does not exist server-side"
+                        )
+                    body = await page.evaluate(
+                        "() => document.body.innerText || ''"
+                    )
+                    if _ITEM_NOT_FOUND_PHRASE in body:
+                        last_reason = (
+                            f"{_ITEM_NOT_FOUND_PHRASE!r} overlay (poll {polls}) "
+                            "— Firestore record exists but content blob is "
+                            "unfetchable in a fresh session (issue #51)"
+                        )
+                        continue
+                    if len(body) < _PLAYABLE_MIN_BODY_CHARS:
+                        last_reason = (
+                            f"body still only {len(body)} chars (poll {polls})"
+                        )
+                        continue
+                    return True, (
+                        f"fresh-context body has {len(body)} chars of content "
+                        f"(settled after {polls} poll{'s' if polls != 1 else ''})"
+                    )
+                return False, (
+                    f"item never became playable in fresh context within "
+                    f"{max_wait:.0f}s ({polls} polls; last: {last_reason})"
+                )
+            finally:
+                await page.close()
+        finally:
+            await fresh_ctx.close()
 
 
 async def get_page_title(url: str) -> str | None:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -18,6 +18,7 @@ from speechify_add.browser import (
     _maybe_delete_partial_item,
     _open_paste_text_modal,
     _StepSkipped,
+    _verify_or_cleanup_fresh_context,
     BrowserSession,
     ADD_TEXT_BUTTON_SELECTORS,
     ADD_TEXT_BUTTON_TIMEOUT_MS,
@@ -334,69 +335,59 @@ class TestBrowserSessionAddUrl:
 # ---------------------------------------------------------------------------
 
 class TestBrowserSessionAddText:
-    def test_raises_on_timeout_no_item_url(self):
-        """RuntimeError raised when page never redirects to /item/ URL."""
+    """BrowserSession.add_text routes text through the file-upload path
+    (issue #51): write a temp .txt and call add_file. We assert the
+    routing contract here; add_file itself has separate coverage.
+    """
+
+    def test_routes_through_add_file_with_tempfile(self):
+        """Text is written to a .txt file and passed to add_file."""
         session = BrowserSession()
-        page = _make_page(url="https://app.speechify.com")
-        session._page = page
+        session._page = _make_page()
+        # _navigate_to_library is called after the upload — stub it.
+        session._navigate_to_library = AsyncMock()
 
-        page.locator = MagicMock()
-        page.wait_for_timeout = AsyncMock()
-        page.goto = AsyncMock()
+        captured = {}
 
-        def locator_side_effect(selector):
-            m = MagicMock()
-            m.wait_for = AsyncMock()
-            m.click = AsyncMock()
-            m.fill = AsyncMock()
-            m.evaluate = AsyncMock()
-            m.first = m
-            return m
+        async def fake_add_file(path, title="", debug=False):
+            # The tempfile must still exist while add_file is running
+            # so Speechify's Firebase upload can read its bytes.
+            assert path.exists(), f"temp file gone before add_file ran: {path}"
+            captured["path"] = path
+            captured["title"] = title
+            captured["text"] = path.read_text(encoding="utf-8")
+            return "https://app.speechify.com/item/abcdef01-2345-6789-abcd-ef0123456789"
 
-        page.locator.side_effect = locator_side_effect
+        async def run():
+            with patch("speechify_add.browser.add_file", new=fake_add_file):
+                return await session.add_text(
+                    "the body text", title="My Title",
+                )
 
-        with pytest.raises(RuntimeError, match="Timed out waiting for Speechify"):
-            asyncio.get_event_loop().run_until_complete(
-                session.add_text("some text", title="My Title")
-            )
+        result = asyncio.get_event_loop().run_until_complete(run())
+        assert result.endswith("abcdef01-2345-6789-abcd-ef0123456789")
+        assert captured["text"] == "the body text"
+        assert captured["title"] == "My Title"
+        assert captured["path"].suffix == ".txt"
+        # And the temp file is cleaned up after add_file returns.
+        assert not captured["path"].exists()
 
-    def test_returns_doc_url_when_redirected(self):
-        """Returns the /item/ URL once page redirects there."""
+    def test_propagates_add_file_exceptions(self):
+        """RuntimeError from add_file (e.g. fresh-context verify failure)
+        propagates so callers see real failures instead of broken URLs."""
         session = BrowserSession()
-        item_uuid = "abcdef01-2345-6789-abcd-ef0123456789"
-        item_url = f"https://app.speechify.com/item/{item_uuid}"
-        page = _make_page(url="https://app.speechify.com")
-        session._page = page
+        session._page = _make_page()
+        session._navigate_to_library = AsyncMock()
 
-        call_count = 0
+        async def run():
+            with patch(
+                "speechify_add.browser.add_file",
+                new=AsyncMock(side_effect=RuntimeError("content blob never persisted")),
+            ):
+                with pytest.raises(RuntimeError, match="content blob never persisted"):
+                    await session.add_text("x")
 
-        async def wait_for_timeout_side(_ms):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 2:
-                page.url = item_url
-
-        page.wait_for_timeout = wait_for_timeout_side
-        page.goto = AsyncMock()
-
-        def locator_side_effect(selector):
-            m = MagicMock()
-            m.wait_for = AsyncMock()
-            m.click = AsyncMock()
-            m.fill = AsyncMock()
-            m.evaluate = AsyncMock()
-            # Verification step uses .count() to look for error-overlay text
-            m.count = AsyncMock(return_value=0)
-            m.first = m
-            return m
-
-        page.locator.side_effect = locator_side_effect
-
-        result = asyncio.get_event_loop().run_until_complete(
-            session.add_text("hello world")
-        )
-        assert "/item/" in result
-        assert result == item_url
+        asyncio.get_event_loop().run_until_complete(run())
 
 
 # ---------------------------------------------------------------------------
@@ -517,48 +508,129 @@ class TestIntegrationBrowserSessionLifecycle:
 
         asyncio.get_event_loop().run_until_complete(run())
 
-    def test_integration_add_text_title_passed_to_fill(self):
-        """When a title is provided, it is passed to input.fill()."""
+    def test_integration_add_text_filename_derived_from_title(self):
+        """Title becomes the temp file's basename so Speechify uses it as
+        the item title (issue #51 routes text through file-upload).
+        """
         async def run():
             session = BrowserSession()
-            page = _make_page(url="https://app.speechify.com")
-            session._page = page
+            session._page = _make_page()
+            session._navigate_to_library = AsyncMock()
+            captured = {}
 
-            fill_calls = []
+            async def fake_add_file(path, title="", debug=False):
+                captured["path"] = path
+                captured["title"] = title
+                return "https://app.speechify.com/item/abcdef01-2345-6789-abcd-ef0123456789"
 
-            async def wait_for_timeout_side(_ms):
-                page.url = "https://app.speechify.com/item/abcdef01-2345-6789-abcd-ef0123456789"
+            with patch("speechify_add.browser.add_file", new=fake_add_file):
+                await session.add_text("body text", title="My Custom Title")
 
-            page.wait_for_timeout = wait_for_timeout_side
-            page.goto = AsyncMock()
-
-            def locator_side_effect(selector):
-                m = MagicMock()
-                m.wait_for = AsyncMock()
-                m.click = AsyncMock()
-                m.evaluate = AsyncMock()
-                # Verification step uses .count() for error-overlay text
-                m.count = AsyncMock(return_value=0)
-                m.first = m
-
-                async def fill_side(val):
-                    fill_calls.append((selector, val))
-
-                m.fill = fill_side
-                return m
-
-            page.locator.side_effect = locator_side_effect
-
-            await session.add_text("body text", title="My Custom Title")
-
-            title_fills = [(s, v) for s, v in fill_calls if 'Optional' in s]
-            assert any("My Custom Title" in v for _, v in title_fills)
+            assert "My-Custom-Title" in captured["path"].name
+            assert captured["title"] == "My Custom Title"
 
         asyncio.get_event_loop().run_until_complete(run())
 
 
 # ---------------------------------------------------------------------------
-# 9. _extract_item_id — pure logic
+# 9. _verify_or_cleanup_fresh_context (issue #51)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyOrCleanupFreshContext:
+    """Post-upload fresh-context verification hook.
+
+    Stubs out ``verify.verify_item_url_fresh_context`` and asserts the
+    retry/cleanup contract: succeed on first OK, retry on transient
+    False until budget exhaustion, then delete + raise.
+    """
+
+    _ITEM_URL = "https://app.speechify.com/item/abcdef01-2345-6789-abcd-ef0123456789"
+    _ITEM_ID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+    def test_returns_quietly_when_first_attempt_passes(self):
+        """If fresh-context verify returns True on attempt 1, exit without delete."""
+        verify_mock = AsyncMock(return_value=(True, "passed"))
+        delete_mock = AsyncMock()
+        sleep_mock = AsyncMock()
+
+        async def run():
+            page = _make_page()
+            with patch(
+                "speechify_add.verify.verify_item_url_fresh_context",
+                new=verify_mock,
+            ), patch(
+                "speechify_add.browser._perform_delete", new=delete_mock,
+            ), patch(
+                "speechify_add.browser.asyncio.sleep", new=sleep_mock,
+            ):
+                await _verify_or_cleanup_fresh_context(
+                    self._ITEM_URL, self._ITEM_ID, page, debug=False,
+                )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert verify_mock.await_count == 1
+        delete_mock.assert_not_awaited()
+
+    def test_raises_after_budget_when_verify_keeps_failing(self):
+        """If verify never succeeds, _perform_delete is called and RuntimeError raised."""
+        verify_mock = AsyncMock(return_value=(False, "Oops! persists"))
+        delete_mock = AsyncMock()
+        # Skip real sleeps so the test doesn't take 90s — the loop will
+        # still terminate because monotonic() ticks forward inside verify_mock.
+        sleep_mock = AsyncMock()
+
+        async def run():
+            page = _make_page(url=self._ITEM_URL)
+            with patch(
+                "speechify_add.verify.verify_item_url_fresh_context",
+                new=verify_mock,
+            ), patch(
+                "speechify_add.browser._perform_delete", new=delete_mock,
+            ), patch(
+                "speechify_add.browser.asyncio.sleep", new=sleep_mock,
+            ), patch(
+                "speechify_add.browser.POST_UPLOAD_VERIFY_BUDGET_SEC", 0.5,
+            ):
+                with pytest.raises(RuntimeError, match="content blob never persisted"):
+                    await _verify_or_cleanup_fresh_context(
+                        self._ITEM_URL, self._ITEM_ID, page, debug=False,
+                    )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert verify_mock.await_count >= 1
+        delete_mock.assert_awaited_once()
+
+    def test_cleanup_failure_does_not_mask_root_error(self):
+        """If _perform_delete itself raises, the RuntimeError about
+        non-persistence is still what reaches the caller — cleanup
+        failure is logged but secondary."""
+        verify_mock = AsyncMock(return_value=(False, "Oops! persists"))
+        delete_mock = AsyncMock(side_effect=RuntimeError("delete also failed"))
+        sleep_mock = AsyncMock()
+
+        async def run():
+            page = _make_page(url=self._ITEM_URL)
+            with patch(
+                "speechify_add.verify.verify_item_url_fresh_context",
+                new=verify_mock,
+            ), patch(
+                "speechify_add.browser._perform_delete", new=delete_mock,
+            ), patch(
+                "speechify_add.browser.asyncio.sleep", new=sleep_mock,
+            ), patch(
+                "speechify_add.browser.POST_UPLOAD_VERIFY_BUDGET_SEC", 0.5,
+            ):
+                with pytest.raises(RuntimeError, match="content blob never persisted"):
+                    await _verify_or_cleanup_fresh_context(
+                        self._ITEM_URL, self._ITEM_ID, page, debug=False,
+                    )
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+
+# ---------------------------------------------------------------------------
+# 10. _extract_item_id — pure logic
 # ---------------------------------------------------------------------------
 
 class TestExtractItemId:
@@ -626,54 +698,40 @@ class TestMaybeDeletePartialItem:
 # 12. BrowserSession.add_text — orphan-cleanup path (issue #39)
 # ---------------------------------------------------------------------------
 
-class TestAddTextVerificationCleanup:
-    _UUID = "cff1772b-7603-4d46-966c-97b4b4566443"
-    _ITEM_URL = f"https://app.speechify.com/item/{_UUID}"
+class TestFilenameFromTitle:
+    """``_filename_from_title`` derives a filesystem-safe filename from
+    the item title so Speechify shows a human-readable name in the
+    library (its file-upload flow uses filename as the displayed title).
+    """
 
-    def test_mid_flow_failure_triggers_orphan_cleanup(self):
-        """If the upload itself fails while page is on /item/<uuid>, the
-        partial item is cleaned up before re-raising."""
-        async def run():
-            session = BrowserSession()
-            # Simulate the page already redirected to the item URL when the
-            # error happened (the half-state described in issue #39).
-            page = _make_page(url=self._ITEM_URL)
-            session._page = page
+    @pytest.mark.parametrize(
+        "title,expected",
+        [
+            ("Simple Title", "Simple-Title"),
+            ("With / slashes \\ and *bad* chars", "With-slashes-and-bad-chars"),
+            ("Unicode — café", "Unicode-caf"),  # non-ASCII stripped
+            ("Extra   whitespace  ", "Extra-whitespace"),
+            ("...leading and trailing...", "leading-and-trailing"),
+        ],
+    )
+    def test_sanitizes(self, title, expected):
+        from speechify_add.browser import _filename_from_title
 
-            with patch(
-                "speechify_add.browser._do_add_text",
-                AsyncMock(side_effect=RuntimeError("Save File click timed out")),
-            ), patch(
-                "speechify_add.browser._perform_delete", AsyncMock()
-            ) as pd:
-                with pytest.raises(RuntimeError, match="Save File"):
-                    await session.add_text("hello")
+        assert _filename_from_title(title) == expected
 
-            pd.assert_awaited_once()
-            assert pd.await_args[0][1] == self._UUID
+    def test_falls_back_when_title_is_unprintable(self):
+        from speechify_add.browser import _filename_from_title
 
-        asyncio.get_event_loop().run_until_complete(run())
+        # Pure punctuation strips to empty — fallback to a sane default.
+        assert _filename_from_title("////") == "speechify-add"
+        assert _filename_from_title("") == "speechify-add"
 
-    def test_mid_flow_failure_no_orphan_when_not_on_item(self):
-        """If the failure happened before any item was created, we don't
-        try to delete anything — there's no UUID to clean up."""
-        async def run():
-            session = BrowserSession()
-            page = _make_page(url="https://app.speechify.com")  # never redirected
-            session._page = page
+    def test_truncates_long_titles(self):
+        from speechify_add.browser import _MAX_FILENAME_LEN, _filename_from_title
 
-            with patch(
-                "speechify_add.browser._do_add_text",
-                AsyncMock(side_effect=RuntimeError("Paste Text menu missing")),
-            ), patch(
-                "speechify_add.browser._perform_delete", AsyncMock()
-            ) as pd:
-                with pytest.raises(RuntimeError, match="Paste Text"):
-                    await session.add_text("hello")
-
-            pd.assert_not_awaited()
-
-        asyncio.get_event_loop().run_until_complete(run())
+        long_title = "a" * 200
+        result = _filename_from_title(long_title)
+        assert len(result) <= _MAX_FILENAME_LEN
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_browser_live.py
+++ b/tests/test_browser_live.py
@@ -42,12 +42,14 @@ def _unique_marker() -> str:
 
 @pytest.mark.live
 async def test_live_upload_verify_delete_roundtrip():
-    """End-to-end: paste text → verify the resulting item URL → delete.
+    """End-to-end: add text → verify the resulting item URL → delete.
 
-    Acts as a canary for any future Speechify UI redesign that breaks
-    one of those steps. The test article has a unique marker so a
-    failed cleanup leaves an obvious breadcrumb instead of polluting
-    the user's library silently.
+    Issue #51: text now routes through the file-upload path because the
+    paste-text path doesn't persist content blobs to Firebase Storage.
+    This test exercises that routing (write tempfile → add_file →
+    fresh-context verify happens internally → URL returned). A failure
+    here means either the file-upload path itself broke (UI rotation)
+    or the fresh-context verify caught a content-persistence regression.
 
     Cleanup uses ``api.delete_item`` (Firebase archive endpoint), which
     is independent of the browser-automation flow being tested.
@@ -61,19 +63,22 @@ async def test_live_upload_verify_delete_roundtrip():
     )
 
     log.info("upload: %s", title)
+    # add_text now performs fresh-context verify internally and only
+    # returns a URL after confirming the item is fetchable by sessions
+    # that didn't do the upload. A successful return is the assertion.
     item_url = await browser.add_text(text, title=title)
     item_id = browser._extract_item_id(item_url)
     assert item_id, f"upload returned a URL with no item UUID: {item_url}"
 
     try:
+        # Belt-and-braces: also run the in-session verify so any future
+        # regression in the chrome-hub render path is visible too.
         ok, info = await verify.verify_item_url(item_id)
         assert ok, (
             f"verify_item_url returned False for {item_id} "
             f"(test article we just uploaded): {info}"
         )
     finally:
-        # Always clean up — even if verify failed, the item is real and
-        # would otherwise pollute the library.
         try:
             await api.delete_item(item_id)
         except Exception as cleanup_err:
@@ -81,4 +86,59 @@ async def test_live_upload_verify_delete_roundtrip():
                 f"cleanup failed for {item_id}: {cleanup_err}. "
                 "The test article is still in the library; delete it "
                 f"manually with: speechify-add delete {item_id} --mode api"
+            )
+
+
+@pytest.mark.live
+async def test_live_fresh_context_verify_catches_paste_text_regression():
+    """Issue #51 regression guard: items uploaded via the deprecated
+    paste-text path render only in the upload session's IndexedDB cache;
+    fresh-context verify must detect this and return False.
+
+    If this test ever returns True, paste-text has either been fixed
+    upstream by Speechify or our cache-bypass detection has broken —
+    investigate before claiming the bug is gone.
+    """
+    marker = _unique_marker()
+    title = f"speechify-add paste-text regression check {marker}"
+    text = (
+        f"Marker {marker}. This article is uploaded via the deprecated "
+        "paste-text path explicitly to confirm fresh-context verify "
+        "catches the issue-51 failure mode. Safe to delete."
+    )
+
+    log.info("paste-text upload: %s", title)
+    async with browser.async_new_page() as page:
+        await browser._init_speechify_page(page)
+        item_url = await browser._do_add_text(page, text, title=title)
+
+    item_id = browser._extract_item_id(item_url)
+    assert item_id, f"paste-text upload returned no UUID: {item_url}"
+
+    try:
+        ok, info = await verify.verify_item_url_fresh_context(
+            item_id, max_wait=20.0,
+        )
+        assert not ok, (
+            f"Fresh-context verify unexpectedly PASSED for paste-text item "
+            f"{item_id}. Either issue #51 has been fixed upstream (great — "
+            "remove this regression guard and the file-upload routing in "
+            "add_text) or our cache-bypass detection broke. Verify info: "
+            f"{info}"
+        )
+        # Sanity: the in-session verify should still pass — proves we're
+        # comparing apples-to-apples (item exists, cache hit makes it look
+        # fine from chrome-hub).
+        ok_cached, info_cached = await verify.verify_item_url(item_id)
+        assert ok_cached, (
+            f"In-session verify also failed for paste-text item — "
+            f"upload may not have completed at all: {info_cached}"
+        )
+    finally:
+        try:
+            await api.delete_item(item_id)
+        except Exception as cleanup_err:
+            pytest.fail(
+                f"cleanup failed for {item_id}: {cleanup_err}. "
+                f"Manual cleanup: speechify-add delete {item_id} --mode api"
             )

--- a/tests/test_browser_live.py
+++ b/tests/test_browser_live.py
@@ -89,56 +89,12 @@ async def test_live_upload_verify_delete_roundtrip():
             )
 
 
-@pytest.mark.live
-async def test_live_fresh_context_verify_catches_paste_text_regression():
-    """Issue #51 regression guard: items uploaded via the deprecated
-    paste-text path render only in the upload session's IndexedDB cache;
-    fresh-context verify must detect this and return False.
-
-    If this test ever returns True, paste-text has either been fixed
-    upstream by Speechify or our cache-bypass detection has broken —
-    investigate before claiming the bug is gone.
-    """
-    marker = _unique_marker()
-    title = f"speechify-add paste-text regression check {marker}"
-    text = (
-        f"Marker {marker}. This article is uploaded via the deprecated "
-        "paste-text path explicitly to confirm fresh-context verify "
-        "catches the issue-51 failure mode. Safe to delete."
-    )
-
-    log.info("paste-text upload: %s", title)
-    async with browser.async_new_page() as page:
-        await browser._init_speechify_page(page)
-        item_url = await browser._do_add_text(page, text, title=title)
-
-    item_id = browser._extract_item_id(item_url)
-    assert item_id, f"paste-text upload returned no UUID: {item_url}"
-
-    try:
-        ok, info = await verify.verify_item_url_fresh_context(
-            item_id, max_wait=20.0,
-        )
-        assert not ok, (
-            f"Fresh-context verify unexpectedly PASSED for paste-text item "
-            f"{item_id}. Either issue #51 has been fixed upstream (great — "
-            "remove this regression guard and the file-upload routing in "
-            "add_text) or our cache-bypass detection broke. Verify info: "
-            f"{info}"
-        )
-        # Sanity: the in-session verify should still pass — proves we're
-        # comparing apples-to-apples (item exists, cache hit makes it look
-        # fine from chrome-hub).
-        ok_cached, info_cached = await verify.verify_item_url(item_id)
-        assert ok_cached, (
-            f"In-session verify also failed for paste-text item — "
-            f"upload may not have completed at all: {info_cached}"
-        )
-    finally:
-        try:
-            await api.delete_item(item_id)
-        except Exception as cleanup_err:
-            pytest.fail(
-                f"cleanup failed for {item_id}: {cleanup_err}. "
-                f"Manual cleanup: speechify-add delete {item_id} --mode api"
-            )
+# NOTE: A regression test attempting to assert "paste-text ALWAYS fails
+# to persist content blobs" was dropped from this PR. Empirical evidence
+# shows the failure is *intermittent*, not consistent — paste-text
+# sometimes persists content correctly. The architectural fix (route
+# add_text through add_file) still stands because file-upload is
+# observed to be reliable where paste-text is not. A statistical
+# reliability test (paste-text persistence rate over N attempts) would
+# be the right shape for a follow-up regression guard but is out of
+# scope here.


### PR DESCRIPTION
## Summary

Closes #51, closes #52.

Speechify's SPA paste-text flow only writes uploaded content to the upload session's local IndexedDB; the background sync to Firebase Storage is unreliable. Items render fine in the browser that did the upload (cache hit) and `"Oops! Something went wrong"` for every other browser. This has been the root cause of broken Speechify URLs in the daily brief for the past three days, masked by a verify check that itself ran inside chrome-hub and saw the cached items as healthy.

Two changes here, plus the test coverage to make the regression visible.

### 1. Route `add_text` through `add_file` (the real fix)

`browser.add_text` now writes the text to a temp `.txt` file and delegates to `add_file`. The file-upload flow POSTs to Firebase Storage explicitly, so resulting items are readable by any authenticated session. The paste-text helpers (`_do_add_text`, `_add_text_with_cleanup`) are kept as deprecated fallbacks but are no longer on the live upload path.

### 2. Fresh-context post-upload verification (the safety net)

`browser.add_file` now runs `_verify_or_cleanup_fresh_context` after every successful upload. This opens a *fresh* `BrowserContext` on the same chrome-hub Chrome — no shared cookies / localStorage / IndexedDB with the upload session — transplants only the Speechify auth cookies, then polls `/item/<uuid>` the way `verify_item_url` does. Up to 90s budget with 5s retry intervals to absorb Speechify's ~30–45s server-side processing delay. If verify never passes, the item is archived and the upload raises instead of returning a broken URL.

New helper: `verify.verify_item_url_fresh_context(item_id, max_wait=...)`. Connects via its own playwright/CDP session, restricts the transplanted cookies to `session`/`axwrt`/`cf_clearance`, and returns the same `(ok, message)` tuple shape as `verify_item_url`.

### Why the original verify path is structurally broken

`verify.verify_item_url` reads from chrome-hub's default `BrowserContext` — the same context that did the upload, with the same IndexedDB caches written during the SPA flow. Items can render fine there even when their content blob never reached Firebase Storage. Every PR that tuned the verify polling/timeout/threshold/retry knobs (#46, #48, #49, #50 here, plus #60/#61/#62 downstream in dailybrief) was measuring an artificial environment. Confirmed by clearing chrome-hub's `speechify-library` / `speechify-cxp-db_<userId>` IndexedDB stores and reloading any "verified" item — immediately produces the `"Oops!"` overlay locally.

### Trade-offs

- Text uploads now take ~50–60s instead of ~10s. Most of the increase is Speechify's server-side processing time before the content blob is fetchable from a fresh context.
- `BrowserSession.add_text` no longer reuses its open page (`add_file` opens its own). Page reuse was a perf optimisation; correctness matters more.
- A regression test I drafted for "paste-text always fails to persist" was dropped: empirically the failure is *intermittent* (some paste-text uploads do persist). A statistical reliability test over N attempts would be the right shape for a follow-up.

## Test plan

- [x] **Unit suite — 279 passed, 16 deselected (live), 0 failed** (`pytest tests/ speechify_add/`)
- [x] **Live suite — 3 passed, 0 failed** (`pytest -m live tests/test_browser_live.py speechify_add/file_upload_live_test.py --forked`)
  - `test_live_upload_verify_delete_roundtrip` — exercises the new `add_text` → file-upload routing end-to-end (62s)
  - `test_upload_txt_round_trip` — file upload + new fresh-context verify hook
  - `test_upload_pdf_round_trip` — file upload + new fresh-context verify hook
- [x] **Manual smoke test** — uploaded two real items via the patched code, both passed fresh-context verify in ~56s each, both confirmed readable by the user from a non-chrome-hub browser:
  - https://app.speechify.com/item/82322ac2-9f03-4ce4-b524-796410043461
  - https://app.speechify.com/item/e1e21a41-acf7-4991-8adc-a392a2a0f25d
- [x] **Reproduction** — pre-fix paste-text items fail fresh-context verify after 90s of polling (3 attempts × 30s); same items render fine in chrome-hub. Clearing chrome-hub's IndexedDB reproduces the user-facing Oops! overlay in chrome-hub itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)