### PR TITLE
test+fix: fresh-context verify unit tests + paste-text reliability sampler + exception-retry

### DIFF
--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -666,9 +666,24 @@ async def _verify_or_cleanup_fresh_context(
         remaining = deadline - time.monotonic()
         # Cap each attempt at remaining-budget so we don't overshoot.
         attempt_wait = min(30.0, max(5.0, remaining))
-        ok, reason = await verify_item_url_fresh_context(
-            item_id, max_wait=attempt_wait,
-        )
+        try:
+            ok, reason = await verify_item_url_fresh_context(
+                item_id, max_wait=attempt_wait,
+            )
+        except Exception as e:
+            # Transient errors during fresh-context navigation —
+            # net::ERR_NETWORK_CHANGED (Chrome's HTTP/2 race),
+            # TargetClosedError (orphan-page cleanup), CDP disconnects —
+            # should be retried within the budget rather than aborting
+            # the whole upload. Failure shape is the same from the
+            # retry loop's perspective whether verify returned False
+            # or raised, so we collapse both into "attempt failed".
+            ok = False
+            reason = f"verify raised {type(e).__name__}: {str(e)[:200]}"
+            log.warning(
+                "Fresh-context verify attempt %d for %s raised %s — retrying",
+                attempt, item_id, type(e).__name__,
+            )
         if ok:
             log.info(
                 "Fresh-context verify passed for %s on attempt %d (%s)",

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -628,6 +628,69 @@ class TestVerifyOrCleanupFreshContext:
 
         asyncio.get_event_loop().run_until_complete(run())
 
+    def test_retries_on_exception_from_verify(self):
+        """Transient exceptions during fresh-context verify (e.g. Chrome's
+        ``net::ERR_NETWORK_CHANGED`` during ``page.goto``, or
+        ``TargetClosedError`` from chrome-hub orphan cleanup) should be
+        caught and counted as a failed attempt, then retried within the
+        budget — not propagated as upload failure.
+        """
+        verify_mock = AsyncMock(side_effect=[
+            RuntimeError("net::ERR_NETWORK_CHANGED transient"),
+            (True, "passed on retry"),
+        ])
+        delete_mock = AsyncMock()
+        sleep_mock = AsyncMock()
+
+        async def run():
+            page = _make_page()
+            with patch(
+                "speechify_add.verify.verify_item_url_fresh_context",
+                new=verify_mock,
+            ), patch(
+                "speechify_add.browser._perform_delete", new=delete_mock,
+            ), patch(
+                "speechify_add.browser.asyncio.sleep", new=sleep_mock,
+            ):
+                await _verify_or_cleanup_fresh_context(
+                    self._ITEM_URL, self._ITEM_ID, page, debug=False,
+                )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        # Two attempts: one that raised, one that succeeded
+        assert verify_mock.await_count == 2
+        # Item was eventually verified, so no cleanup
+        delete_mock.assert_not_awaited()
+
+    def test_exhausts_budget_when_verify_keeps_raising(self):
+        """If every attempt raises (transient errors all the way down),
+        the budget eventually expires, cleanup runs, and a RuntimeError
+        with the exception class name in the reason is propagated."""
+        verify_mock = AsyncMock(side_effect=RuntimeError("ERR_NETWORK_CHANGED"))
+        delete_mock = AsyncMock()
+        sleep_mock = AsyncMock()
+
+        async def run():
+            page = _make_page(url=self._ITEM_URL)
+            with patch(
+                "speechify_add.verify.verify_item_url_fresh_context",
+                new=verify_mock,
+            ), patch(
+                "speechify_add.browser._perform_delete", new=delete_mock,
+            ), patch(
+                "speechify_add.browser.asyncio.sleep", new=sleep_mock,
+            ), patch(
+                "speechify_add.browser.POST_UPLOAD_VERIFY_BUDGET_SEC", 0.5,
+            ):
+                with pytest.raises(RuntimeError, match="content blob never persisted"):
+                    await _verify_or_cleanup_fresh_context(
+                        self._ITEM_URL, self._ITEM_ID, page, debug=False,
+                    )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert verify_mock.await_count >= 1
+        delete_mock.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # 10. _extract_item_id — pure logic

--- a/tests/test_browser_live.py
+++ b/tests/test_browser_live.py
@@ -89,12 +89,155 @@ async def test_live_upload_verify_delete_roundtrip():
             )
 
 
-# NOTE: A regression test attempting to assert "paste-text ALWAYS fails
-# to persist content blobs" was dropped from this PR. Empirical evidence
-# shows the failure is *intermittent*, not consistent — paste-text
-# sometimes persists content correctly. The architectural fix (route
-# add_text through add_file) still stands because file-upload is
-# observed to be reliable where paste-text is not. A statistical
-# reliability test (paste-text persistence rate over N attempts) would
-# be the right shape for a follow-up regression guard but is out of
-# scope here.
+@pytest.mark.live
+async def test_live_paste_text_reliability_sampler():
+    """Sample the reliability of the deprecated paste-text path (issue #51).
+
+    Uploads ``N`` items via the SPA paste-text flow, then for each checks
+    whether the body marker round-trips to a fresh browser context (no
+    shared IndexedDB with the uploader). Logs the success rate at WARNING
+    so it shows up in pytest output.
+
+    Why a sampler instead of a hard regression guard:
+    - Paste-text persistence is *intermittent*. Some uploads do persist
+      content to Firebase Storage, others don't. A "must fail" assertion
+      flakes; a "must succeed" assertion is the bug we're trying to
+      detect; only a rate is meaningful, and that needs N attempts.
+    - The test is informational, not a release-blocker. ``add_text``
+      already routes through the file-upload path (issue #51 fix); this
+      sampler exists to surface when paste-text starts working reliably
+      enough to be worth reconsidering that workaround.
+
+    Tail of the contract: assert that ``len(results) == N`` (test ran
+    end-to-end), but make no claim about the success rate itself. Loud
+    log lines carry the signal.
+
+    Cleanup: every uploaded item is archived via ``api.delete_item`` —
+    even ones that didn't render content for the fresh context. The
+    Firestore record exists either way, so archive succeeds.
+    """
+    from playwright.async_api import async_playwright
+
+    from chrome_hub.browser import CDP_URL
+    from speechify_add.verify import _FRESH_AUTH_COOKIE_NAMES
+
+    N = 5  # ~30-60s per attempt → ~3-5 min total
+
+    async def _body_for_fresh_context(item_id: str, timeout_s: float = 45.0) -> str:
+        """Open ``/item/<item_id>`` in a fresh BrowserContext and return
+        the rendered body. We use marker-presence (not the verify
+        threshold heuristic) for content detection: the threshold check
+        falsely passes on auth-form flashes that have >150 chars of
+        Speechify chrome but none of our body text."""
+        async with async_playwright() as pw:
+            cdp_browser = await pw.chromium.connect_over_cdp(CDP_URL)
+            auth_cookies = []
+            if cdp_browser.contexts:
+                all_cookies = await cdp_browser.contexts[0].cookies(
+                    ["https://app.speechify.com/", "https://speechify.com/"]
+                )
+                auth_cookies = [
+                    c for c in all_cookies
+                    if c.get("name") in _FRESH_AUTH_COOKIE_NAMES
+                ]
+            assert auth_cookies, (
+                "no Speechify auth cookies in chrome-hub default context — "
+                "this test cannot run without an authenticated chrome-hub session"
+            )
+
+            fresh_ctx = await cdp_browser.new_context()
+            try:
+                await fresh_ctx.add_cookies(auth_cookies)
+                page = await fresh_ctx.new_page()
+                try:
+                    await page.goto(
+                        f"https://app.speechify.com/item/{item_id}",
+                        wait_until="load", timeout=30_000,
+                    )
+                    await page.wait_for_timeout(int(timeout_s * 1000))
+                    return await page.evaluate(
+                        "() => document.body ? document.body.innerText : ''"
+                    )
+                finally:
+                    await page.close()
+            finally:
+                await fresh_ctx.close()
+
+    item_ids: list[str] = []
+    results: list[bool] = []
+
+    for i in range(N):
+        marker = _unique_marker()
+        body_marker = f"PASTE-TEXT-SAMPLER-MARKER-{marker}-{i}"
+        title = f"speechify-add paste-text sampler {marker}-{i}"
+        text = (
+            f"{body_marker}\n\nPaste-text reliability sample {i + 1}/{N}. "
+            "If you see this in your library, the test left behind an "
+            "un-archived item — safe to delete manually. "
+            + ("Padding text. " * 20)
+        )
+
+        log.warning("paste-text sample %d/%d: uploading", i + 1, N)
+        try:
+            async with browser.async_new_page() as page:
+                await browser._init_speechify_page(page)
+                item_url = await browser._do_add_text(page, text, title=title)
+        except Exception as e:
+            log.warning("paste-text sample %d/%d: upload failed: %s", i + 1, N, e)
+            results.append(False)
+            continue
+
+        item_id = browser._extract_item_id(item_url)
+        if not item_id:
+            log.warning(
+                "paste-text sample %d/%d: upload returned no UUID (%r)",
+                i + 1, N, item_url,
+            )
+            results.append(False)
+            continue
+        item_ids.append(item_id)
+
+        try:
+            body = await _body_for_fresh_context(item_id)
+        except Exception as e:
+            log.warning(
+                "paste-text sample %d/%d: fresh-context fetch raised %s",
+                i + 1, N, e,
+            )
+            results.append(False)
+            continue
+
+        persisted = body_marker in body
+        results.append(persisted)
+        log.warning(
+            "paste-text sample %d/%d: %s (body had %d chars)",
+            i + 1, N, "PERSISTED" if persisted else "BROKEN", len(body),
+        )
+
+    # Cleanup — archive every item created, even broken ones.
+    for item_id in item_ids:
+        try:
+            await api.delete_item(item_id)
+        except Exception as cleanup_err:
+            log.warning(
+                "paste-text sampler: cleanup of %s failed: %s. "
+                "Manual: speechify-add delete %s --mode api",
+                item_id, cleanup_err, item_id,
+            )
+
+    # Headline log line — pytest -v shows this so a human can spot it.
+    success_rate = (sum(results) / len(results)) if results else 0.0
+    log.warning(
+        "paste-text reliability sampler: %d/%d persisted (%.0f%%) — "
+        "issue #51 workaround is %s",
+        sum(results), len(results), success_rate * 100,
+        "still warranted" if success_rate < 1.0
+        else "potentially removable; investigate",
+    )
+
+    # We only assert the test ran end-to-end. No claim on the rate —
+    # paste-text behaviour varies, and a single run isn't statistically
+    # informative on its own. See docstring.
+    assert len(results) == N, (
+        f"sampler aborted early: collected {len(results)}/{N} attempts"
+    )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -16,6 +16,7 @@ from speechify_add.verify import (
     parse_progress_pct,
     search_library_batch,
     verify_item_url,
+    verify_item_url_fresh_context,
 )
 
 
@@ -341,3 +342,230 @@ class TestVerifyItemUrl:
             ok, info = await verify_item_url(self.UUID, max_wait=10)
         assert ok is False
         assert "redirected" in info.lower()
+
+
+# ---------------------------------------------------------------------------
+# verify_item_url_fresh_context (issue #51)
+# ---------------------------------------------------------------------------
+
+def _mock_fresh_context_playwright(*, url, body_sequence, cookies=None):
+    """Build the mock pipeline ``verify_item_url_fresh_context`` walks
+    through: ``async_playwright()`` → ``chromium.connect_over_cdp`` →
+    ``browser.contexts[0].cookies`` (auth) → ``browser.new_context()`` →
+    fresh ``page.goto`` + polling.
+
+    ``cookies`` is the list returned by ``default_ctx.cookies(...)``; if
+    None, defaults to a single ``session`` cookie. Tests that exercise
+    the cookie filter pass a richer cookie list and inspect the
+    ``add_cookies`` call afterward.
+
+    Returns ``(playwright_cm, refs)`` where ``refs`` exposes the mocked
+    page, fresh_ctx, default_ctx, and browser so tests can assert on
+    call arguments (which cookies were transplanted, etc.).
+    """
+    if cookies is None:
+        cookies = [{"name": "session", "value": "fake-jwt", "domain": ".speechify.com"}]
+
+    page = MagicMock()
+    page.url = url
+    page.goto = AsyncMock()
+    page.wait_for_timeout = AsyncMock()
+    page.close = AsyncMock()
+
+    # evaluate(...) yields successive bodies, then repeats the last one
+    # forever — matching the existing _mock_item_page_cm semantics.
+    iterator = iter(body_sequence)
+    last_body = body_sequence[-1] if body_sequence else ""
+
+    async def _eval(_js):
+        nonlocal last_body
+        try:
+            last_body = next(iterator)
+        except StopIteration:
+            pass
+        return last_body
+
+    page.evaluate = _eval
+
+    fresh_ctx = MagicMock()
+    fresh_ctx.new_page = AsyncMock(return_value=page)
+    fresh_ctx.add_cookies = AsyncMock()
+    fresh_ctx.close = AsyncMock()
+
+    default_ctx = MagicMock()
+    default_ctx.cookies = AsyncMock(return_value=cookies)
+
+    browser = MagicMock()
+    browser.contexts = [default_ctx]
+    browser.new_context = AsyncMock(return_value=fresh_ctx)
+
+    chromium = MagicMock()
+    chromium.connect_over_cdp = AsyncMock(return_value=browser)
+
+    pw = MagicMock()
+    pw.chromium = chromium
+
+    playwright_cm = MagicMock()
+    playwright_cm.__aenter__ = AsyncMock(return_value=pw)
+    playwright_cm.__aexit__ = AsyncMock(return_value=None)
+
+    refs = {
+        "page": page,
+        "fresh_ctx": fresh_ctx,
+        "default_ctx": default_ctx,
+        "browser": browser,
+    }
+    return playwright_cm, refs
+
+
+class TestVerifyItemUrlFreshContext:
+    """Issue #51: fresh-context verify reads the item page from a
+    BrowserContext that didn't do the upload — no shared IndexedDB,
+    so it sees what every other browser sees (not the cached version).
+    """
+
+    UUID = "abcdef01-2345-6789-abcd-ef0123456789"
+    GOOD_BODY = (
+        "Real Article Title\nShare\n\nA full body of meaningful content "
+        "going on for hundreds of characters because this is what a real "
+        "Speechify item page looks like with title, summary, and player "
+        "controls all rendered." * 2
+    )
+    OOPS_BODY = (
+        "Oops! Something went wrong\n\nRefresh the page or try again later.\n"
+        "\nReturn to My Library\nNeed help? Contact support"
+    )
+
+    @pytest.mark.asyncio
+    async def test_passes_immediately_for_healthy_item(self):
+        """Body has real content on first poll → returns True with a
+        ``settled after 1 poll`` message."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.GOOD_BODY],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=10)
+        assert ok is True
+        assert "settled after 1 poll" in info
+
+    @pytest.mark.asyncio
+    async def test_settles_after_initial_oops(self):
+        """Mirrors the scenario where the item page briefly shows the
+        Oops! overlay right after navigation before settling to real
+        content. The poller must keep going across overlay polls and
+        return True once the body becomes real."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.OOPS_BODY, self.OOPS_BODY, self.GOOD_BODY],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=10)
+        assert ok is True
+        assert "settled after 3 polls" in info
+
+    @pytest.mark.asyncio
+    async def test_fails_when_oops_persists(self):
+        """The exact issue #51 failure mode: content blob isn't on the
+        server, so the Oops! overlay never clears. Must return False
+        with a clear message after the deadline."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.OOPS_BODY],  # repeats forever
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=4)
+        assert ok is False
+        assert "Oops" in info
+        assert "never became playable" in info
+        assert "issue #51" in info
+
+    @pytest.mark.asyncio
+    async def test_fails_on_short_body(self):
+        """A non-Oops but near-empty body (e.g. auth flash, partial
+        render) must NOT pass — too short to be real content."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=["loading…"],  # 8 chars, well below threshold
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=4)
+        assert ok is False
+        assert "never became playable" in info
+
+    @pytest.mark.asyncio
+    async def test_fails_when_redirected_off_item_page(self):
+        """If the fresh context lands somewhere other than /item/<uuid>
+        (auth bounce, item-not-found redirect), bail immediately."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url="https://app.speechify.com/auth/web/",
+            body_sequence=["irrelevant"],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=10)
+        assert ok is False
+        assert "redirected" in info.lower()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_no_auth_cookies(self):
+        """If chrome-hub's default context has no Speechify session
+        cookie, fresh-context verify cannot authenticate. Return a
+        clear False rather than try-and-redirect-to-login."""
+        cm, _refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.GOOD_BODY],
+            cookies=[
+                # All non-auth tracking cookies — should be filtered out
+                {"name": "_ga", "value": "GA1.x", "domain": ".speechify.com"},
+                {"name": "_fbp", "value": "fb.1.y", "domain": ".speechify.com"},
+            ],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, info = await verify_item_url_fresh_context(self.UUID, max_wait=10)
+        assert ok is False
+        assert "no Speechify auth cookies" in info
+
+    @pytest.mark.asyncio
+    async def test_only_transplants_recognised_auth_cookies(self):
+        """Only cookies in ``_FRESH_AUTH_COOKIE_NAMES`` should reach the
+        fresh context — analytics / ad cookies stay out so the fresh
+        context renders cleanly without tracker interference."""
+        cm, refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.GOOD_BODY],
+            cookies=[
+                {"name": "session", "value": "AUTH-JWT", "domain": ".speechify.com"},
+                {"name": "axwrt", "value": "AUTH-AXWRT", "domain": "speechify.com"},
+                {"name": "cf_clearance", "value": "CF", "domain": ".speechify.com"},
+                {"name": "_ga", "value": "tracker", "domain": ".speechify.com"},
+                {"name": "intercom-session-fix72gk8", "value": "im", "domain": ".speechify.com"},
+                {"name": "ajs_user_id", "value": "uid", "domain": ".app.speechify.com"},
+            ],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            ok, _info = await verify_item_url_fresh_context(self.UUID, max_wait=10)
+        assert ok is True
+
+        refs["fresh_ctx"].add_cookies.assert_awaited_once()
+        transplanted = refs["fresh_ctx"].add_cookies.await_args[0][0]
+        transplanted_names = {c["name"] for c in transplanted}
+        assert transplanted_names == {"session", "axwrt", "cf_clearance"}
+        # Trackers must not leak into the fresh context
+        assert "_ga" not in transplanted_names
+        assert "ajs_user_id" not in transplanted_names
+
+    @pytest.mark.asyncio
+    async def test_closes_fresh_context_even_on_failure(self):
+        """Resource cleanup: the fresh ``BrowserContext`` and ``page``
+        must close whether verify passes or fails. Without this we'd
+        leak Chrome tabs across retry loops in ``_verify_or_cleanup_fresh_context``.
+        """
+        cm, refs = _mock_fresh_context_playwright(
+            url=f"https://app.speechify.com/item/{self.UUID}",
+            body_sequence=[self.OOPS_BODY],
+        )
+        with patch("speechify_add.verify.async_playwright", return_value=cm):
+            await verify_item_url_fresh_context(self.UUID, max_wait=2)
+
+        refs["page"].close.assert_awaited_once()
+        refs["fresh_ctx"].close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Follow-up to #53. Closes the two action items noted in that PR's review:

1. **Unit-level mock tests for `verify_item_url_fresh_context`** — eight tests covering the polling/cookie-transplant/cleanup contract without a live chrome-hub. Closes a yellow flag from #53's review.

2. **Live paste-text reliability sampler** — replaces the flawed "paste-text always fails" regression guard dropped from #53. Samples N=5 attempts and logs the persistence rate at WARNING. Empirically informative without trying to assert a brittle outcome.

3. **Plus a small fix surfaced by running the live tests:** `_verify_or_cleanup_fresh_context` now catches exceptions from `verify_item_url_fresh_context` (e.g. Chrome's `net::ERR_NETWORK_CHANGED`, `TargetClosedError`) and counts them as a failed attempt instead of aborting the upload. Without this, a single Chrome flake mid-upload would fail the whole `add_text` call, defeating the retry budget.

## Notable observation

Today's sampler run printed:

> `paste-text reliability sampler: 5/5 persisted (100%) — issue #51 workaround is potentially removable; investigate`

24 hours ago, paste-text was producing 0/5 in the same setup. Either Speechify shipped a backend fix or this is a lucky window. Not flipping the decision in this PR — the workaround in `add_text` (route through file-upload) is cheap enough to leave in place pending several days of sampler data. The new test is the instrument for that data.

## Test plan

- [x] **Unit suite — 289 passed, 0 failed** (was 279 before #53, now +10 from #53 and this PR combined).
- [x] **Live suite — 2 passed, 0 failed** (`pytest -m live tests/test_browser_live.py --forked`):
  - `test_live_upload_verify_delete_roundtrip` — passed cleanly (the exception-retry fix proved itself; an earlier run had hit `net::ERR_NETWORK_CHANGED` and aborted before the fix).
  - `test_live_paste_text_reliability_sampler` — passed with 5/5 PERSISTED rate logged.
- [x] **Cookie-filter regression coverage**: `test_only_transplants_recognised_auth_cookies` explicitly asserts that only `{session, axwrt, cf_clearance}` reach the fresh context, even when the default context has analytics / Intercom / `ajs_user_id` cookies that would leak fingerprinting state if they were transplanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)