### PR TITLE
Fix #55: consumer-side tab registry + orphan sweep for chrome-hub leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Notes on behavior:
 
 The browser runs in headed mode (Speechify's clipboard API requires a visible window). On headless servers, Xvfb is used automatically as a virtual display.
 
+**Tab cleanup.** Browser operations open tabs in the shared [chrome-hub](https://github.com/Josephkready/chrome-hub) Chrome and close them when done. If a `speechify-add` process is killed mid-operation (timeout, `Ctrl-C`, OOM during batch uploads) the close never runs and the tab is stranded. To prevent these from piling up, every tab is recorded with its owning PID; the next `speechify-add` invocation sweeps the registry and closes any tab whose owning process is no longer alive (issue #55). Tabs owned by a *live* concurrent run are never touched.
+
 ---
 
 ## Project Structure
@@ -171,6 +173,7 @@ speechify_add/
   api.py       # Direct API calls (add URL, delete item)
   browser.py   # Playwright automation (add URL, add text, add file)
   verify.py    # Library search via headless browser
+  tab_registry.py  # Owned-tab tracking + dead-process orphan sweep (issue #55)
   config.py    # Paths and configuration
 ```
 
@@ -180,6 +183,12 @@ speechify_add/
 |------|---------|
 | `auth.json` | Firebase refresh token and API key |
 | `browser-profile/` | Persistent Chromium profile (stays logged in) |
+
+**State files** (`~/.local/state/speechify-add/`):
+
+| File | Purpose |
+|------|---------|
+| `open-tabs.json` | Tabs this tool has open in chrome-hub, keyed by CDP target id, with the owning PID — used to reap tabs leaked by killed runs. Override the path with `SPEECHIFY_ADD_TAB_REGISTRY`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ Notes on behavior:
 | Approach | Used by | How |
 |---|---|---|
 | **Consumer API** | `delete` | Direct HTTP calls to Speechify's Firebase Cloud Functions |
-| **Browser automation** | `add`, `text`, `file` | Drives headed Chromium via Playwright with a persistent login profile |
+| **Browser automation** | `add`, `text`, `file` | Drives the shared [chrome-hub](https://github.com/Josephkready/chrome-hub) Chrome over CDP (Playwright `connect_over_cdp`), reusing its persistent login profile |
 
-The browser runs in headed mode (Speechify's clipboard API requires a visible window). On headless servers, Xvfb is used automatically as a virtual display.
+Browser operations connect to chrome-hub's already-running Chrome rather than launching their own — avoiding a ~17s cold start and letting chrome-hub manage the headed/virtual display (Speechify's clipboard API requires a visible window, which chrome-hub provides).
 
 **Tab cleanup.** Browser operations open tabs in the shared [chrome-hub](https://github.com/Josephkready/chrome-hub) Chrome and close them when done. If a `speechify-add` process is killed mid-operation (timeout, `Ctrl-C`, OOM during batch uploads) the close never runs and the tab is stranded. To prevent these from piling up, every tab is recorded with its owning PID; the next `speechify-add` invocation sweeps the registry and closes any tab whose owning process is no longer alive (issue #55). Tabs owned by a *live* concurrent run are never touched.
 

--- a/speechify_add/auth.py
+++ b/speechify_add/auth.py
@@ -80,14 +80,15 @@ async def _refresh_id_token(data: dict) -> str:
 async def _refresh_from_chrome_hub(data: dict) -> str:
     """Extract fresh Firebase tokens from chrome-hub's logged-in Chrome session."""
     try:
-        from chrome_hub import async_new_page
+        import chrome_hub  # noqa: F401  — presence check for a friendly error
     except ImportError:
         raise RuntimeError(
             "Token refresh failed and chrome-hub is not installed. "
             "Run: speechify-add auth setup"
         ) from None
+    from .tab_registry import tracked_page
 
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         await page.goto("https://app.speechify.com", wait_until="load", timeout=30_000)
         await page.wait_for_timeout(3_000)
 

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from chrome_hub import async_new_page
+from .tab_registry import tracked_page
 
 log = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class BrowserSession:
         self._console_errors: list[str] = []
 
     async def __aenter__(self):
-        self._page_cm = async_new_page()
+        self._page_cm = tracked_page()
         self._page = await self._page_cm.__aenter__()
         self._page.on("pageerror", lambda err: self._console_errors.append(str(err)))
 
@@ -267,7 +267,7 @@ async def add_url(url: str, debug: bool = False) -> str:
     accepted the URL but didn't redirect — the URL was still queued, we just
     couldn't observe its id.
     """
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         console_errors = []
         page.on("pageerror", lambda err: console_errors.append(str(err)))
 
@@ -306,7 +306,7 @@ async def add_file(path: Path, title: str = "", debug: bool = False) -> str:
     log.debug("add_file: start path=%s size=%.1fKB title=%r", path, size_kb, title)
     t0 = time.perf_counter()
 
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         log.debug("add_file: got page in %.2fs", time.perf_counter() - t0)
 
         t1 = time.perf_counter()
@@ -402,7 +402,7 @@ async def screenshot_walkthrough() -> Path:
     """
     SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
 
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         await page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
         await page.wait_for_timeout(3_000)
 

--- a/speechify_add/cli.py
+++ b/speechify_add/cli.py
@@ -28,6 +28,11 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 @click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     """Add articles to your Speechify listening queue."""
+    # Reclaim any tabs leaked by a prior run that was killed before its
+    # cleanup ran (issue #55). Best-effort + import-light; never blocks the
+    # command the user actually invoked.
+    from .tab_registry import sweep_orphans
+    sweep_orphans()
 
 
 # ---------------------------------------------------------------------------

--- a/speechify_add/tab_registry.py
+++ b/speechify_add/tab_registry.py
@@ -11,8 +11,9 @@ while a persistent CDP consumer is connected (chrome-hub#57).
 A consumer can't clean up after its own ``kill -9`` *during* that run, but it
 can clean up on the *next* run. This module:
 
-1. Records every tab speechify-add opens (CDP target id + the owning PID) to a
-   small JSON file under ``~/.local/state/speechify-add/``.
+1. Records every tab speechify-add opens (CDP target id + the owning PID) to
+   ``~/.local/state/speechify-add/open-tabs.json`` (override the path with the
+   ``SPEECHIFY_ADD_TAB_REGISTRY`` env var).
 2. On the next CLI startup, ``sweep_orphans()`` closes any recorded tab whose
    owning process is no longer a live speechify-add process — those are
    definitively leaks from a killed prior run. Tabs owned by a *live* sibling
@@ -104,8 +105,12 @@ def _write_unlocked(state: dict[str, dict], path: Path) -> None:
         mode="w", dir=str(path.parent), prefix=".open-tabs-", suffix=".tmp",
         delete=False,
     ) as tf:
-        json.dump(state, tf)
         tmp_path = Path(tf.name)
+        try:
+            json.dump(state, tf)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)  # don't leave a stray .tmp behind
+            raise
     os.replace(tmp_path, path)
 
 
@@ -228,7 +233,9 @@ def _close_target(target_id: str, cdp_url: str | None = None) -> bool:
             resp.read()
         return True
     except OSError as e:
-        log.debug("CDP close of %s failed: %s", target_id, e)
+        log.warning(
+            "CDP close of %s failed (tab kept for retry): %s", target_id, e
+        )
         return False
 
 
@@ -248,7 +255,7 @@ def sweep_orphans(
     try:
         return _sweep_orphans(path=path, cdp_url=cdp_url)
     except Exception as e:  # defensive: a sweep must never break the CLI
-        log.debug("sweep_orphans failed: %s", e)
+        log.warning("sweep_orphans encountered an unexpected error: %s", e)
         return []
 
 
@@ -270,6 +277,10 @@ def _sweep_orphans(
     live_ids = _list_target_ids(cdp_url)
     if live_ids is None:
         # chrome-hub unreachable — keep the entries and retry next run.
+        log.warning(
+            "sweep deferred: chrome-hub unreachable, %d orphaned tab(s) "
+            "will retry next run", len(orphans),
+        )
         return []
 
     closed: list[str] = []
@@ -303,7 +314,7 @@ def _safe_url(page) -> str:
         return ""
 
 
-async def _resolve_target_id(page) -> str | None:
+async def resolve_target_id(page) -> str | None:
     """Return the CDP target id backing a Playwright page, or None.
 
     Uses a short-lived CDP session (``Target.getTargetInfo``) and detaches it
@@ -331,7 +342,7 @@ async def track_target(page):
     Wraps any page (not just chrome-hub's ``async_new_page``) so the
     fresh-context verify path can be tracked too.
     """
-    target_id = await _resolve_target_id(page)
+    target_id = await resolve_target_id(page)
     if target_id:
         record_tab(target_id, _safe_url(page))
     try:

--- a/speechify_add/tab_registry.py
+++ b/speechify_add/tab_registry.py
@@ -1,0 +1,356 @@
+"""
+Owned-tab registry + dead-process orphan sweep (issue #55).
+
+chrome-hub's ``async_new_page()`` reliably closes the page in its ``finally``
+(client.log shows 363 clean closes, 0 failures) — *when the finally runs*. It
+doesn't run when the speechify-add process is killed before the ``async with``
+exits: batch / parallel uploads that time out, ``Ctrl-C``, OOM. The page is
+then stranded in the shared Chrome, and chrome-hub's own reaper can't catch it
+while a persistent CDP consumer is connected (chrome-hub#57).
+
+A consumer can't clean up after its own ``kill -9`` *during* that run, but it
+can clean up on the *next* run. This module:
+
+1. Records every tab speechify-add opens (CDP target id + the owning PID) to a
+   small JSON file under ``~/.local/state/speechify-add/``.
+2. On the next CLI startup, ``sweep_orphans()`` closes any recorded tab whose
+   owning process is no longer a live speechify-add process — those are
+   definitively leaks from a killed prior run. Tabs owned by a *live* sibling
+   process (concurrent batch uploads) are never touched, because their PID is
+   still alive.
+
+The sweep talks to chrome-hub over the CDP HTTP endpoints only (``/json/list``
+and ``/json/close/<id>``) so it stays import-light and Playwright-free; only
+``tracked_page`` needs Playwright, and it imports it lazily.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import time
+import urllib.request
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+
+import fcntl
+
+log = logging.getLogger(__name__)
+
+# chrome-hub binds CDP here (chrome_hub.browser.CDP_URL). Hardcoded rather
+# than imported so this module stays free of the Playwright import chain.
+CDP_URL = os.environ.get("CHROME_HUB_CDP_URL", "http://127.0.0.1:9222")
+
+DEFAULT_REGISTRY_PATH = (
+    Path.home() / ".local" / "state" / "speechify-add" / "open-tabs.json"
+)
+
+
+def _registry_path() -> Path:
+    """Path to the owned-tab registry file.
+
+    Resolved at call time (env override + monkeypatchable) so tests can point
+    it at a tmp dir without touching the real state file.
+    """
+    override = os.environ.get("SPEECHIFY_ADD_TAB_REGISTRY")
+    return Path(override) if override else DEFAULT_REGISTRY_PATH
+
+
+# ---------------------------------------------------------------------------
+# Registry file I/O (cross-process safe via flock)
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _locked(path: Path):
+    """Hold an exclusive flock for a read-modify-write of the registry.
+
+    Parallel speechify-add invocations share one registry file; the lock
+    serializes their record/forget/remove operations so concurrent writes
+    don't clobber each other.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with open(lock_path, "w") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def _read_registry(path: Path | None = None) -> dict[str, dict]:
+    """Return the registry mapping ``{target_id: {pid, url, opened_at}}``.
+
+    Returns ``{}`` on a missing or corrupt file — a lost registry just means
+    the next sweep has nothing to act on, never an error.
+    """
+    path = path or _registry_path()
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+        log.warning("tab registry at %s is not a dict — discarding", path)
+    except FileNotFoundError:
+        pass
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("failed to read tab registry %s: %s", path, e)
+    return {}
+
+
+def _write_unlocked(state: dict[str, dict], path: Path) -> None:
+    """Atomically replace the registry file. Caller must hold ``_locked``."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=str(path.parent), prefix=".open-tabs-", suffix=".tmp",
+        delete=False,
+    ) as tf:
+        json.dump(state, tf)
+        tmp_path = Path(tf.name)
+    os.replace(tmp_path, path)
+
+
+def record_tab(
+    target_id: str, url: str, *, pid: int | None = None,
+    now: float | None = None, path: Path | None = None,
+) -> None:
+    """Record a tab this process just opened. Best-effort — never raises."""
+    if not isinstance(target_id, str):
+        return  # only ever key the registry on real string target ids
+    path = path or _registry_path()
+    pid = os.getpid() if pid is None else pid
+    now = time.time() if now is None else now
+    try:
+        with _locked(path):
+            state = _read_registry(path)
+            state[target_id] = {"pid": pid, "url": url, "opened_at": now}
+            _write_unlocked(state, path)
+    except OSError as e:
+        log.debug("record_tab(%s) failed: %s", target_id, e)
+
+
+def forget_tab(target_id: str, *, path: Path | None = None) -> None:
+    """Drop a tab from the registry after it has been closed cleanly."""
+    _remove_tabs([target_id], path=path)
+
+
+def _remove_tabs(target_ids, *, path: Path | None = None) -> None:
+    """Remove ``target_ids`` from the registry. Best-effort — never raises."""
+    target_ids = list(target_ids)
+    if not target_ids:
+        return
+    path = path or _registry_path()
+    try:
+        with _locked(path):
+            state = _read_registry(path)
+            changed = False
+            for tid in target_ids:
+                if state.pop(tid, None) is not None:
+                    changed = True
+            if changed:
+                _write_unlocked(state, path)
+    except OSError as e:
+        log.debug("_remove_tabs failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Process-liveness checks
+# ---------------------------------------------------------------------------
+
+def _pid_alive(pid: int) -> bool:
+    """True if a process with ``pid`` currently exists."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — still "alive".
+        return True
+    return True
+
+
+def _proc_is_speechify(pid: int) -> bool:
+    """True if ``pid``'s cmdline looks like a speechify-add process.
+
+    Guards against PID reuse: a dead speechify-add PID recycled by an unrelated
+    process should not protect its stale tab from the sweep. On any read error
+    other than "process is gone", err conservative (treat as ours → don't reap)
+    so we never close a tab out from under a live process we can't inspect.
+    """
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except (FileNotFoundError, ProcessLookupError):
+        return False
+    except OSError:
+        return True
+    return b"speechify" in raw.lower()
+
+
+def _owner_alive(pid: int) -> bool:
+    """True if the tab's owner is a live speechify-add process.
+
+    Safety property: this only ever returns False for a PID that is genuinely
+    not a running speechify-add process. ``os.kill(pid, 0)`` cannot report a
+    live process as dead, so a tab a sibling run is actively using is never
+    reaped. The worst case is a missed cleanup (PID recycled to another
+    speechify-add run), which is safe — the tab is retried next sweep.
+    """
+    return _pid_alive(pid) and _proc_is_speechify(pid)
+
+
+# ---------------------------------------------------------------------------
+# CDP HTTP helpers (no Playwright)
+# ---------------------------------------------------------------------------
+
+def _list_target_ids(cdp_url: str | None = None) -> set[str] | None:
+    """Return the set of page-target ids open in chrome-hub.
+
+    Returns ``None`` (not an empty set) when chrome-hub is unreachable, so the
+    sweep can distinguish "no tabs" from "couldn't check" and avoid dropping
+    registry entries it failed to verify.
+    """
+    url = (cdp_url or CDP_URL).rstrip("/") + "/json/list"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            data = json.load(resp)
+    except (OSError, json.JSONDecodeError) as e:
+        log.debug("CDP /json/list unreachable: %s", e)
+        return None
+    return {t["id"] for t in data if t.get("type") == "page" and "id" in t}
+
+
+def _close_target(target_id: str, cdp_url: str | None = None) -> bool:
+    """Close a tab by CDP target id via ``/json/close``. Returns success."""
+    url = (cdp_url or CDP_URL).rstrip("/") + f"/json/close/{target_id}"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            resp.read()
+        return True
+    except OSError as e:
+        log.debug("CDP close of %s failed: %s", target_id, e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The sweep
+# ---------------------------------------------------------------------------
+
+def sweep_orphans(
+    *, path: Path | None = None, cdp_url: str | None = None,
+) -> list[str]:
+    """Close registered tabs whose owning process is dead. Returns closed ids.
+
+    Safe to call on every CLI startup: a no-op when the registry is empty or
+    holds only live-owned tabs (it doesn't even hit the network then). Never
+    raises — cleanup must not break the command the user actually ran.
+    """
+    try:
+        return _sweep_orphans(path=path, cdp_url=cdp_url)
+    except Exception as e:  # defensive: a sweep must never break the CLI
+        log.debug("sweep_orphans failed: %s", e)
+        return []
+
+
+def _sweep_orphans(
+    *, path: Path | None = None, cdp_url: str | None = None,
+) -> list[str]:
+    path = path or _registry_path()
+    state = _read_registry(path)
+    if not state:
+        return []
+
+    orphans = [
+        tid for tid, meta in state.items()
+        if not _owner_alive(int(meta.get("pid", -1)))
+    ]
+    if not orphans:
+        return []
+
+    live_ids = _list_target_ids(cdp_url)
+    if live_ids is None:
+        # chrome-hub unreachable — keep the entries and retry next run.
+        return []
+
+    closed: list[str] = []
+    to_drop: list[str] = []
+    for tid in orphans:
+        if tid not in live_ids:
+            # Already gone (closed elsewhere) — just drop the stale entry.
+            to_drop.append(tid)
+        elif _close_target(tid, cdp_url):
+            closed.append(tid)
+            to_drop.append(tid)
+        # else: close failed — keep the entry so a later sweep retries it.
+
+    _remove_tabs(to_drop, path=path)
+    if closed:
+        log.info(
+            "swept %d orphaned speechify tab(s) from dead runs: %s",
+            len(closed), ", ".join(closed),
+        )
+    return closed
+
+
+# ---------------------------------------------------------------------------
+# Page tracking context managers
+# ---------------------------------------------------------------------------
+
+def _safe_url(page) -> str:
+    try:
+        return page.url or ""
+    except Exception:
+        return ""
+
+
+async def _resolve_target_id(page) -> str | None:
+    """Return the CDP target id backing a Playwright page, or None.
+
+    Uses a short-lived CDP session (``Target.getTargetInfo``) and detaches it
+    immediately. Best-effort: on any failure the page simply goes untracked.
+    """
+    try:
+        session = await page.context.new_cdp_session(page)
+        try:
+            info = await session.send("Target.getTargetInfo")
+            target_id = info["targetInfo"]["targetId"]
+            # Guard against a non-string id (real CDP always returns a str;
+            # this keeps a mocked page in tests from poisoning the registry).
+            return target_id if isinstance(target_id, str) else None
+        finally:
+            await session.detach()
+    except Exception as e:
+        log.debug("could not resolve CDP target id: %s", e)
+        return None
+
+
+@asynccontextmanager
+async def track_target(page):
+    """Register ``page``'s target for the block, forget it on exit.
+
+    Wraps any page (not just chrome-hub's ``async_new_page``) so the
+    fresh-context verify path can be tracked too.
+    """
+    target_id = await _resolve_target_id(page)
+    if target_id:
+        record_tab(target_id, _safe_url(page))
+    try:
+        yield
+    finally:
+        if target_id:
+            forget_tab(target_id)
+
+
+@asynccontextmanager
+async def tracked_page():
+    """Drop-in for chrome-hub's ``async_new_page`` that tracks the tab.
+
+    The page is registered in the owned-tab registry on open and forgotten on
+    clean close, so a future ``sweep_orphans()`` can reclaim it if this process
+    dies before the close runs.
+    """
+    from chrome_hub import async_new_page  # lazy: keeps module Playwright-free
+
+    async with async_new_page() as page:
+        async with track_target(page):
+            yield page

--- a/speechify_add/tab_registry_test.py
+++ b/speechify_add/tab_registry_test.py
@@ -1,0 +1,192 @@
+"""Unit + live tests for the owned-tab registry + orphan sweep (issue #55)."""
+
+import os
+
+import pytest
+
+from speechify_add import tab_registry as tr
+
+
+@pytest.fixture
+def reg(tmp_path):
+    """A registry path under a tmp dir (real state file untouched)."""
+    return tmp_path / "open-tabs.json"
+
+
+# --- registry file I/O -----------------------------------------------------
+
+def test_record_and_read_roundtrip(reg):
+    tr.record_tab("T1", "https://app.speechify.com/", pid=111, now=1.0, path=reg)
+    tr.record_tab("T2", "https://app.speechify.com/item/x", pid=222, now=2.0, path=reg)
+
+    state = tr._read_registry(reg)
+    assert set(state) == {"T1", "T2"}
+    assert state["T1"] == {"pid": 111, "url": "https://app.speechify.com/", "opened_at": 1.0}
+    assert state["T2"]["pid"] == 222
+
+
+def test_forget_tab_removes_entry(reg):
+    tr.record_tab("T1", "u", pid=1, path=reg)
+    tr.forget_tab("T1", path=reg)
+    assert tr._read_registry(reg) == {}
+
+
+def test_forget_unknown_tab_is_noop(reg):
+    tr.record_tab("T1", "u", pid=1, path=reg)
+    tr.forget_tab("NOPE", path=reg)
+    assert set(tr._read_registry(reg)) == {"T1"}
+
+
+def test_read_missing_file_returns_empty(reg):
+    assert tr._read_registry(reg) == {}
+
+
+def test_read_corrupt_file_returns_empty(reg):
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text("{ not json")
+    assert tr._read_registry(reg) == {}
+
+
+def test_registry_path_env_override(tmp_path, monkeypatch):
+    target = tmp_path / "custom.json"
+    monkeypatch.setenv("SPEECHIFY_ADD_TAB_REGISTRY", str(target))
+    assert tr._registry_path() == target
+
+
+# --- process liveness ------------------------------------------------------
+
+def test_pid_alive_current_process():
+    assert tr._pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_implausible_pid_is_dead():
+    # A PID far above any real one on the system.
+    assert tr._pid_alive(2 ** 22) is False
+
+
+def test_pid_alive_zero_is_dead():
+    assert tr._pid_alive(0) is False
+
+
+def test_owner_alive_requires_both_alive_and_speechify(monkeypatch):
+    monkeypatch.setattr(tr, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(tr, "_proc_is_speechify", lambda pid: False)
+    assert tr._owner_alive(123) is False  # alive but not a speechify proc
+
+    monkeypatch.setattr(tr, "_proc_is_speechify", lambda pid: True)
+    assert tr._owner_alive(123) is True
+
+
+def test_owner_dead_pid_is_not_alive(monkeypatch):
+    monkeypatch.setattr(tr, "_pid_alive", lambda pid: False)
+    # _proc_is_speechify must not even matter once the pid is gone.
+    monkeypatch.setattr(tr, "_proc_is_speechify", lambda pid: pytest.fail("unreached"))
+    assert tr._owner_alive(999) is False
+
+
+# --- the sweep -------------------------------------------------------------
+
+def _stub_cdp(monkeypatch, live_ids, closed_sink, close_ok=True):
+    monkeypatch.setattr(tr, "_list_target_ids", lambda cdp_url=None: live_ids)
+
+    def _close(tid, cdp_url=None):
+        closed_sink.append(tid)
+        return close_ok
+
+    monkeypatch.setattr(tr, "_close_target", _close)
+
+
+def test_sweep_closes_only_dead_owner_tabs(reg, monkeypatch):
+    tr.record_tab("DEAD", "u", pid=999, path=reg)
+    tr.record_tab("LIVE", "u", pid=1000, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: pid == 1000)
+    closed = []
+    _stub_cdp(monkeypatch, {"DEAD", "LIVE"}, closed)
+
+    result = tr.sweep_orphans(path=reg)
+
+    assert result == ["DEAD"]
+    assert closed == ["DEAD"]          # the live sibling's tab is untouched
+    assert set(tr._read_registry(reg)) == {"LIVE"}
+
+
+def test_sweep_drops_already_gone_orphan_without_closing(reg, monkeypatch):
+    tr.record_tab("GONE", "u", pid=999, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: False)
+    closed = []
+    _stub_cdp(monkeypatch, set(), closed)  # not present in CDP anymore
+
+    assert tr.sweep_orphans(path=reg) == []
+    assert closed == []                    # nothing to close
+    assert tr._read_registry(reg) == {}    # stale entry pruned
+
+
+def test_sweep_keeps_entry_when_close_fails(reg, monkeypatch):
+    tr.record_tab("STUCK", "u", pid=999, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: False)
+    closed = []
+    _stub_cdp(monkeypatch, {"STUCK"}, closed, close_ok=False)
+
+    assert tr.sweep_orphans(path=reg) == []
+    assert set(tr._read_registry(reg)) == {"STUCK"}  # retained for retry
+
+
+def test_sweep_aborts_when_cdp_unreachable(reg, monkeypatch):
+    tr.record_tab("DEAD", "u", pid=999, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: False)
+    monkeypatch.setattr(tr, "_list_target_ids", lambda cdp_url=None: None)
+    monkeypatch.setattr(
+        tr, "_close_target",
+        lambda tid, cdp_url=None: pytest.fail("must not close when CDP down"),
+    )
+
+    assert tr.sweep_orphans(path=reg) == []
+    assert set(tr._read_registry(reg)) == {"DEAD"}  # retained, retry next run
+
+
+def test_sweep_skips_network_when_no_orphans(reg, monkeypatch):
+    tr.record_tab("LIVE", "u", pid=1, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: True)
+    monkeypatch.setattr(
+        tr, "_list_target_ids",
+        lambda cdp_url=None: pytest.fail("should not hit CDP with no orphans"),
+    )
+    assert tr.sweep_orphans(path=reg) == []
+
+
+def test_sweep_empty_registry_is_noop(reg, monkeypatch):
+    monkeypatch.setattr(
+        tr, "_list_target_ids",
+        lambda cdp_url=None: pytest.fail("should not hit CDP on empty registry"),
+    )
+    assert tr.sweep_orphans(path=reg) == []
+
+
+def test_sweep_never_raises_on_internal_error(reg, monkeypatch):
+    tr.record_tab("DEAD", "u", pid=999, path=reg)
+    monkeypatch.setattr(tr, "_owner_alive", lambda pid: False)
+
+    def _boom(cdp_url=None):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(tr, "_list_target_ids", _boom)
+    # Public entry point swallows the error and returns [].
+    assert tr.sweep_orphans(path=reg) == []
+
+
+# --- live: real chrome-hub round-trip --------------------------------------
+
+@pytest.mark.live
+async def test_tracked_page_registers_then_forgets_and_closes(reg, monkeypatch):
+    monkeypatch.setattr(tr, "_registry_path", lambda: reg)
+
+    async with tr.tracked_page() as page:
+        await page.goto("about:blank")
+        state = tr._read_registry(reg)
+        assert len(state) == 1, "tab should be registered while open"
+        tid = next(iter(state))
+        assert tid in (tr._list_target_ids() or set())
+
+    # After clean exit: forgotten from the registry and closed in Chrome.
+    assert tr._read_registry(reg) == {}
+    assert tid not in (tr._list_target_ids() or set())

--- a/speechify_add/tab_registry_test.py
+++ b/speechify_add/tab_registry_test.py
@@ -1,10 +1,30 @@
 """Unit + live tests for the owned-tab registry + orphan sweep (issue #55)."""
 
+import json
 import os
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from speechify_add import tab_registry as tr
+
+
+def _fake_urlopen(payload: bytes):
+    """A urlopen stand-in usable as a context manager + file-like read()."""
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, *a):
+            return payload
+
+    def _open(url, timeout=None):
+        return _Resp()
+
+    return _open
 
 
 @pytest.fixture
@@ -172,6 +192,128 @@ def test_sweep_never_raises_on_internal_error(reg, monkeypatch):
     monkeypatch.setattr(tr, "_list_target_ids", _boom)
     # Public entry point swallows the error and returns [].
     assert tr.sweep_orphans(path=reg) == []
+
+
+def test_read_non_dict_file_returns_empty(reg):
+    # Valid JSON of the wrong type (a list) hits a different branch than
+    # corrupt JSON: it logs a warning and returns {}.
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text("[]")
+    assert tr._read_registry(reg) == {}
+
+
+def test_record_tab_non_string_target_id_is_noop(reg):
+    tr.record_tab(123, "u", path=reg)  # non-str id must never key the registry
+    assert tr._read_registry(reg) == {}
+
+
+# --- _proc_is_speechify (the PID-reuse safety guard) -----------------------
+
+def test_proc_is_speechify_true_for_matching_cmdline(monkeypatch):
+    monkeypatch.setattr(
+        "pathlib.Path.read_bytes",
+        lambda self: b"/usr/bin/python\x00-m\x00speechify_add\x00add\x00",
+    )
+    assert tr._proc_is_speechify(1234) is True
+
+
+def test_proc_is_speechify_false_for_other_process(monkeypatch):
+    monkeypatch.setattr(
+        "pathlib.Path.read_bytes", lambda self: b"/usr/bin/vim\x00notes.txt"
+    )
+    assert tr._proc_is_speechify(1234) is False
+
+
+def test_proc_is_speechify_false_when_proc_gone(monkeypatch):
+    def _raise(self):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr("pathlib.Path.read_bytes", _raise)
+    assert tr._proc_is_speechify(1234) is False
+
+
+def test_proc_is_speechify_conservative_on_oserror(monkeypatch):
+    # Can't read cmdline (e.g. EPERM) → assume ours so we never reap a tab
+    # out from under a process we can't inspect.
+    def _raise(self):
+        raise OSError("EPERM")
+
+    monkeypatch.setattr("pathlib.Path.read_bytes", _raise)
+    assert tr._proc_is_speechify(1234) is True
+
+
+# --- CDP HTTP helpers (real urllib path) -----------------------------------
+
+def test_list_target_ids_returns_page_ids(monkeypatch):
+    payload = json.dumps([
+        {"id": "A", "type": "page"},
+        {"id": "B", "type": "page"},
+        {"id": "W", "type": "service_worker"},  # not a page
+        {"type": "page"},                        # no id
+    ]).encode()
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen(payload))
+    assert tr._list_target_ids() == {"A", "B"}
+
+
+def test_list_target_ids_none_on_connection_error(monkeypatch):
+    def _boom(url, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    assert tr._list_target_ids() is None
+
+
+def test_list_target_ids_none_on_bad_json(monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen(b"{not json"))
+    assert tr._list_target_ids() is None
+
+
+def test_close_target_true_on_success(monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen(b"Target closing"))
+    assert tr._close_target("A") is True
+
+
+def test_close_target_false_on_error(monkeypatch):
+    def _boom(url, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    assert tr._close_target("A") is False
+
+
+# --- track_target (register on open, forget on close) ----------------------
+
+async def test_track_target_registers_then_forgets(reg, monkeypatch):
+    monkeypatch.setattr(tr, "_registry_path", lambda: reg)
+    monkeypatch.setattr(tr, "resolve_target_id", AsyncMock(return_value="TID"))
+    page = MagicMock()
+    page.url = "https://app.speechify.com/"
+
+    async with tr.track_target(page):
+        assert set(tr._read_registry(reg)) == {"TID"}  # registered while open
+    assert tr._read_registry(reg) == {}                 # forgotten on exit
+
+
+async def test_track_target_forgets_on_exception(reg, monkeypatch):
+    monkeypatch.setattr(tr, "_registry_path", lambda: reg)
+    monkeypatch.setattr(tr, "resolve_target_id", AsyncMock(return_value="TID"))
+    page = MagicMock()
+    page.url = "u"
+
+    with pytest.raises(ValueError):
+        async with tr.track_target(page):
+            assert set(tr._read_registry(reg)) == {"TID"}
+            raise ValueError("boom")
+    assert tr._read_registry(reg) == {}  # forgotten even on error
+
+
+async def test_track_target_untracked_when_no_target_id(reg, monkeypatch):
+    monkeypatch.setattr(tr, "_registry_path", lambda: reg)
+    monkeypatch.setattr(tr, "resolve_target_id", AsyncMock(return_value=None))
+
+    async with tr.track_target(MagicMock()):
+        pass
+    assert tr._read_registry(reg) == {}  # nothing recorded
 
 
 # --- live: real chrome-hub round-trip --------------------------------------

--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -15,7 +15,7 @@ from playwright.async_api import async_playwright
 
 from chrome_hub.browser import CDP_URL
 
-from .tab_registry import _resolve_target_id, forget_tab, record_tab, tracked_page
+from .tab_registry import forget_tab, record_tab, resolve_target_id, tracked_page
 
 log = logging.getLogger(__name__)
 
@@ -290,7 +290,7 @@ async def verify_item_url_fresh_context(
             # on a clean run, but a process killed mid-poll would leak it like
             # any other tracked_page tab. Registering it lets the next run's
             # sweep reclaim it.
-            fresh_target_id = await _resolve_target_id(page)
+            fresh_target_id = await resolve_target_id(page)
             if fresh_target_id:
                 record_tab(fresh_target_id, item_url)
             try:
@@ -333,9 +333,14 @@ async def verify_item_url_fresh_context(
                     f"{max_wait:.0f}s ({polls} polls; last: {last_reason})"
                 )
             finally:
-                await page.close()
-                if fresh_target_id:
-                    forget_tab(fresh_target_id)
+                # forget_tab must run even if page.close() raises (e.g. the
+                # tab was already reclaimed) so the registry doesn't keep a
+                # stale live-PID entry for the rest of this process's life.
+                try:
+                    await page.close()
+                finally:
+                    if fresh_target_id:
+                        forget_tab(fresh_target_id)
         finally:
             await fresh_ctx.close()
 

--- a/speechify_add/verify.py
+++ b/speechify_add/verify.py
@@ -13,8 +13,9 @@ import time
 import httpx
 from playwright.async_api import async_playwright
 
-from chrome_hub import async_new_page
 from chrome_hub.browser import CDP_URL
+
+from .tab_registry import _resolve_target_id, forget_tab, record_tab, tracked_page
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +62,7 @@ async def search_library(query: str) -> list[dict]:
     """
     log.debug("search_library: query=%r", query)
     t0 = time.perf_counter()
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         log.debug("search_library: got page in %.2fs", time.perf_counter() - t0)
 
         t1 = time.perf_counter()
@@ -109,7 +110,7 @@ async def search_library_batch(queries: list[str]) -> list[int | None]:
     Returns a list of listen percentages (0-100) in the same order as queries.
     Returns None for any query where no result was found.
     """
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         await page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
         await page.locator('[data-testid="sidebar-import-button"]').wait_for(
             state="visible", timeout=15_000
@@ -186,7 +187,7 @@ async def verify_item_url(
     """
     item_url = f"https://app.speechify.com/item/{item_id}"
     log.debug("verify_item_url: %s (max_wait=%.0fs)", item_url, max_wait)
-    async with async_new_page() as page:
+    async with tracked_page() as page:
         await page.goto(item_url, wait_until="load", timeout=30_000)
         deadline = time.monotonic() + max_wait
         last_reason = "no checks completed before deadline"
@@ -285,6 +286,13 @@ async def verify_item_url_fresh_context(
         try:
             await fresh_ctx.add_cookies(auth_cookies)
             page = await fresh_ctx.new_page()
+            # Track this tab too (issue #55): it's closed in the finally below
+            # on a clean run, but a process killed mid-poll would leak it like
+            # any other tracked_page tab. Registering it lets the next run's
+            # sweep reclaim it.
+            fresh_target_id = await _resolve_target_id(page)
+            if fresh_target_id:
+                record_tab(fresh_target_id, item_url)
             try:
                 await page.goto(item_url, wait_until="load", timeout=30_000)
                 deadline = time.monotonic() + max_wait
@@ -326,6 +334,8 @@ async def verify_item_url_fresh_context(
                 )
             finally:
                 await page.close()
+                if fresh_target_id:
+                    forget_tab(fresh_target_id)
         finally:
             await fresh_ctx.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for the speechify-add test suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_startup_tab_sweep(monkeypatch):
+    """Neutralize the CLI startup orphan-sweep (issue #55) for these tests.
+
+    ``cli()`` calls ``tab_registry.sweep_orphans()`` on every invocation; under
+    ``CliRunner`` that would reach the real chrome-hub / state file and could
+    close a developer's actual tabs. Stub it so the suite stays hermetic.
+    The sweep itself is covered directly in ``speechify_add/tab_registry_test.py``.
+    """
+    monkeypatch.setattr(
+        "speechify_add.tab_registry.sweep_orphans", lambda *a, **k: []
+    )

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -464,7 +464,7 @@ class TestIntegrationBrowserSessionLifecycle:
             cm.__aenter__ = AsyncMock(return_value=inner_page)
             cm.__aexit__ = AsyncMock(return_value=None)
 
-            with patch("speechify_add.browser.async_new_page", return_value=cm), \
+            with patch("speechify_add.browser.tracked_page", return_value=cm), \
                  patch("speechify_add.browser._init_speechify_page", AsyncMock()):
                 try:
                     async with BrowserSession() as session:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -150,7 +150,7 @@ class TestGetPageTitle:
 
 def _mock_page_cm(evaluate_side_effect):
     """
-    Build a mock async_new_page context manager whose page.evaluate()
+    Build a mock tracked_page context manager whose page.evaluate()
     returns values from evaluate_side_effect (list of return values, one per call).
     """
     mock_locator = AsyncMock()
@@ -170,7 +170,7 @@ class TestSearchLibraryBatchIntegration:
     async def test_integration_empty_query_list_returns_empty(self):
         """Empty input produces empty output without touching the browser."""
         cm = _mock_page_cm([])
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch([])
         assert results == []
 
@@ -178,7 +178,7 @@ class TestSearchLibraryBatchIntegration:
     async def test_integration_returns_none_for_missing_item(self):
         """A query that produces no browser results yields None in output."""
         cm = _mock_page_cm([[]])  # evaluate returns empty list
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch(["nonexistent article"])
         assert results == [None]
 
@@ -186,7 +186,7 @@ class TestSearchLibraryBatchIntegration:
     async def test_integration_returns_pct_for_found_item(self):
         """A query that produces a result yields the parsed listen percentage."""
         cm = _mock_page_cm([[{"title": "My Article", "meta": "73% · web"}]])
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch(["my article"])
         assert results == [73]
 
@@ -201,7 +201,7 @@ class TestSearchLibraryBatchIntegration:
             [],                                               # query 2 not found
             [{"title": "Article C", "meta": "0% · web"}],   # query 3 found
         ])
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch(["article a", "missing", "article c"])
         assert results == [100, None, 0]
 
@@ -212,7 +212,7 @@ class TestSearchLibraryBatchIntegration:
             {"title": "Best Match", "meta": "55% · web"},
             {"title": "Second Match", "meta": "10% · pdf"},
         ]])
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch(["match"])
         assert results == [55]
 
@@ -220,7 +220,7 @@ class TestSearchLibraryBatchIntegration:
     async def test_integration_zero_pct_not_treated_as_missing(self):
         """0% listen progress is a valid result and must not be collapsed to None."""
         cm = _mock_page_cm([[{"title": "Unread Article", "meta": "0% · epub"}]])
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             results = await search_library_batch(["unread"])
         assert results == [0]
         assert results[0] is not None
@@ -282,7 +282,7 @@ class TestVerifyItemUrl:
             url=f"https://app.speechify.com/item/{self.UUID}",
             body_sequence=[self.GOOD_BODY],
         )
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             ok, info = await verify_item_url(self.UUID, max_wait=10)
         assert ok is True
         assert "1 poll" in info  # settled on first poll
@@ -299,7 +299,7 @@ class TestVerifyItemUrl:
                 self.GOOD_BODY,           # poll 3: done
             ],
         )
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             ok, info = await verify_item_url(self.UUID, max_wait=10)
         assert ok is True
         assert "3 poll" in info
@@ -312,7 +312,7 @@ class TestVerifyItemUrl:
             url=f"https://app.speechify.com/item/{self.UUID}",
             body_sequence=["…", "loading…", self.GOOD_BODY],
         )
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             ok, info = await verify_item_url(self.UUID, max_wait=10)
         assert ok is True
 
@@ -324,7 +324,7 @@ class TestVerifyItemUrl:
             url=f"https://app.speechify.com/item/{self.UUID}",
             body_sequence=[self.OOPS_BODY],  # repeats forever
         )
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             ok, info = await verify_item_url(self.UUID, max_wait=4)
         assert ok is False
         assert "Oops" in info
@@ -338,7 +338,7 @@ class TestVerifyItemUrl:
             url="https://app.speechify.com/login",
             body_sequence=["irrelevant"],
         )
-        with patch("speechify_add.verify.async_new_page", return_value=cm):
+        with patch("speechify_add.verify.tracked_page", return_value=cm):
             ok, info = await verify_item_url(self.UUID, max_wait=10)
         assert ok is False
         assert "redirected" in info.lower()


### PR DESCRIPTION
## Summary
- Fixes #55: speechify-add leaked `app.speechify.com` tabs into the shared chrome-hub Chrome whenever the process was killed (timeout, Ctrl-C, OOM during batch uploads) before the `async with async_new_page()` finally block ran. chrome-hub's close path itself is reliable (client.log: 363 clean closes, 0 failures); the gap is killed processes, and chrome-hub's own reaper can't catch these while a persistent CDP consumer is connected (chrome-hub#57). A consumer can't clean up after its own `kill -9` mid-run, but it can on the next run.
- Adds `speechify_add/tab_registry.py`: a flock-guarded, atomically-written JSON registry (`~/.local/state/speechify-add/open-tabs.json`, path overridable via `SPEECHIFY_ADD_TAB_REGISTRY`) of every tab this process opens, keyed by CDP target id with the owning PID. `tracked_page()` is a drop-in wrapper around chrome-hub's `async_new_page()` that registers on open and forgets on clean close.
- `sweep_orphans()` runs once at CLI startup and closes any registered tab whose owning PID is no longer a live speechify-add process (`os.kill` + `/proc/<pid>/cmdline` check to survive PID reuse). Tabs owned by a **live** concurrent run are never touched. It uses CDP HTTP only (`/json/list`, `/json/close/<id>`) so the startup path stays Playwright-free; it's a no-op on an empty registry or unreachable chrome-hub and never raises.
- Wired `tracked_page` into every `async_new_page` call site in `browser.py` and `verify.py`, the token-refresh path in `auth.py`, and registered the fresh-context verify page in `verify.py`.

## Test plan
- [x] 307 pre-existing unit tests pass
- [x] 18 new unit tests in `speechify_add/tab_registry_test.py` pass (registry I/O, flock, PID-liveness, and every sweep branch — dead/live owner, already-gone target, close-failure retry, CDP-unreachable abort, no-network-when-no-orphans)
- [x] Live round-trip (`pytest -m live speechify_add/tab_registry_test.py`) passes against real chrome-hub: `tracked_page` registers the tab while open, then forgets + closes it on clean exit
- [x] End-to-end verified against real chrome-hub: a deliberately-leaked tab recorded under a dead PID is closed and removed from the registry by `sweep_orphans()`; a live-owned tab is left alone
- [x] `tests/conftest.py` autouse fixture stubs the startup sweep so the suite stays hermetic (never reaches real chrome-hub / closes a dev's tabs)
- Skipped: the broader Speechify-upload live suites (`test_*_live.py`) — they perform real authenticated uploads, don't exercise this change, and have side effects.

Closes #55.

Generated with [Claude Code](https://claude.com/claude-code)