### PR TITLE
speechify-add: fail fast on logged-out session instead of 15s timeout

### DIFF
--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -150,6 +150,11 @@ class BrowserSession:
     async def _navigate_to_library(self):
         """Navigate back to the Speechify library between operations."""
         await self._page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
+        # Same fast-fail as _init_speechify_page: if the session expired
+        # mid-batch, the sidebar never renders and the wait below would burn
+        # its full 15s timeout with an opaque error. Catch the /auth redirect
+        # first so the batch aborts with an actionable "Session expired".
+        _assert_logged_in(self._page)
         await self._page.locator('[data-testid="sidebar-import-button"]').wait_for(
             state="visible", timeout=15_000
         )
@@ -494,6 +499,7 @@ async def screenshot_walkthrough() -> Path:
 
 def _assert_logged_in(page):
     if any(s in page.url for s in ("/login", "/signin", "/sign-in", "/auth")):
+        log.warning("Session expired: redirected to %s", page.url)
         raise RuntimeError("Session expired. Run: speechify-add auth setup")
 
 

--- a/speechify_add/browser.py
+++ b/speechify_add/browser.py
@@ -91,12 +91,21 @@ async def _init_speechify_page(page):
     t0 = time.perf_counter()
     await page.goto("https://app.speechify.com", wait_until="load", timeout=60_000)
     log.debug("init: page.goto(load) done in %.2fs", time.perf_counter() - t0)
+    # Fail fast on a logged-out session. app.speechify.com redirects to the
+    # auth page, where the sidebar never renders — so without this check the
+    # sidebar wait below burns its full 15s timeout and surfaces an opaque
+    # "Locator.wait_for: Timeout exceeded", which callers (e.g. dailybrief)
+    # misread as a transient error and retry 3x per item. Checking the URL
+    # first turns that into an immediate, actionable "Session expired".
+    _assert_logged_in(page)
     t1 = time.perf_counter()
     await page.locator('[data-testid="sidebar-import-button"]').wait_for(
         state="visible", timeout=15_000
     )
     log.debug("init: sidebar visible in %.2fs", time.perf_counter() - t1)
     await page.wait_for_timeout(1_000)
+    # Re-check after the app has fully settled: a stale session can render the
+    # shell briefly before the SPA bounces to /auth.
     _assert_logged_in(page)
     log.debug("init: total %.2fs", time.perf_counter() - t0)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -245,6 +245,37 @@ class TestBrowserSessionInit:
         assert s.debug is True
 
 
+class TestBrowserSessionNavigateToLibrary:
+    def _session(self, url):
+        session = BrowserSession()
+        page = _make_page(url=url)
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.locator = MagicMock(return_value=_make_locator(visible=True))
+        session._page = page
+        return session, page
+
+    def test_logged_out_fails_before_sidebar_wait(self):
+        """A session that expired mid-batch must fast-fail on the next
+        navigation rather than burn the 15s sidebar timeout."""
+        session, page = self._session(
+            "https://speechify.com/auth/web/?returnTo=https%3A%2F%2Fapp.speechify.com%2F"
+        )
+        with pytest.raises(RuntimeError, match="Session expired"):
+            asyncio.get_event_loop().run_until_complete(
+                session._navigate_to_library()
+            )
+        page.goto.assert_awaited_once()
+        page.locator.assert_not_called()  # never reached the sidebar wait
+
+    def test_logged_in_waits_for_sidebar(self):
+        session, page = self._session("https://app.speechify.com/")
+        asyncio.get_event_loop().run_until_complete(
+            session._navigate_to_library()
+        )  # must not raise
+        page.locator.assert_called_with('[data-testid="sidebar-import-button"]')
+
+
 # ---------------------------------------------------------------------------
 # 5. BrowserSession.__aexit__ does not suppress exceptions
 # ---------------------------------------------------------------------------

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -12,6 +12,7 @@ import pytest_asyncio
 
 from speechify_add.browser import (
     _assert_logged_in,
+    _init_speechify_page,
     _extract_item_id,
     _find_first_visible,
     _click_first_visible,
@@ -61,6 +62,8 @@ class TestAssertLoggedIn:
         "https://app.speechify.com/sign-in",
         "https://app.speechify.com/auth",
         "https://app.speechify.com/auth?redirect=/",
+        # Real-world logged-out redirect observed 2026-07-08 (dailybrief 0/20).
+        "https://speechify.com/auth/web/?returnTo=https%3A%2F%2Fapp.speechify.com%2F",
     ])
     def test_raises_on_login_urls(self, login_url):
         page = _make_page(url=login_url)
@@ -75,6 +78,37 @@ class TestAssertLoggedIn:
     def test_no_error_on_authenticated_urls(self, ok_url):
         page = _make_page(url=ok_url)
         _assert_logged_in(page)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 1b. _init_speechify_page — fail fast on logged-out session
+# ---------------------------------------------------------------------------
+
+class TestInitSpeechifyPage:
+    def _page(self, url):
+        page = _make_page(url=url)
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.locator = MagicMock(return_value=_make_locator(visible=True))
+        return page
+
+    def test_logged_out_fails_before_sidebar_wait(self):
+        """A redirect to /auth must raise immediately, without ever waiting on
+        the sidebar locator (that 15s timeout is the bug this guards against)."""
+        page = self._page(
+            "https://speechify.com/auth/web/?returnTo=https%3A%2F%2Fapp.speechify.com%2F"
+        )
+        with pytest.raises(RuntimeError, match="Session expired"):
+            asyncio.get_event_loop().run_until_complete(_init_speechify_page(page))
+        page.goto.assert_awaited_once()
+        page.locator.assert_not_called()  # never reached the sidebar wait
+
+    def test_logged_in_waits_for_sidebar(self):
+        page = self._page("https://app.speechify.com/")
+        asyncio.get_event_loop().run_until_complete(
+            _init_speechify_page(page)
+        )  # must not raise
+        page.locator.assert_called_with('[data-testid="sidebar-import-button"]')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- On 2026-07-08 the dailybrief digest shipped with 0/20 Speechify listen links because the shared chrome-hub browser's Speechify session had silently logged out. `app.speechify.com` redirects a logged-out session to `https://speechify.com/auth/web/?returnTo=...`, where the library sidebar never renders.
- `_init_speechify_page()` was waiting up to 15s on the `[data-testid="sidebar-import-button"]` locator and only calling `_assert_logged_in()` afterward, so a logged-out session surfaced as an opaque `Locator.wait_for: Timeout 15000ms exceeded` rather than a clear "Session expired" message. dailybrief misread that opaque timeout as transient and retried 3x per story (~13 minutes wasted, still 0 links).
- Fix: call `_assert_logged_in(page)` immediately after `page.goto(...)` (before the sidebar wait), and again after the app settles. A logged-out session now raises `RuntimeError("Session expired. Run: speechify-add auth setup")` in ~1-2s — a message dailybrief already recognizes as an auth issue, so the batch fails fast with an actionable log line instead of retrying.

## Test plan
- [x] Added `TestInitSpeechifyPage.test_logged_out_fails_before_sidebar_wait` — asserts the fast-fail path never reaches the sidebar locator wait
- [x] Added `TestInitSpeechifyPage.test_logged_in_waits_for_sidebar` — confirms the happy path still waits for the sidebar as before
- [x] Added the real-world observed logged-out redirect URL (`https://speechify.com/auth/web/?returnTo=...`) to the `_assert_logged_in` parametrized cases
- [x] Full non-live test suite passes (324 passed). Live suite skipped: change is pure URL-check logic fully covered by unit tests, and the live suite would collide with an in-flight chrome-hub re-upload.

Generated with [Claude Code](https://claude.com/claude-code)